### PR TITLE
refactor: gtm preview mode

### DIFF
--- a/apps/nest-backend/src/inspector/inspector-group-events.service.ts
+++ b/apps/nest-backend/src/inspector/inspector-group-events.service.ts
@@ -48,7 +48,7 @@ export class InspectorGroupEventsService {
 
     const results = [];
     for (let i = 0; i < operations.length; i += concurrency) {
-      const incognitoContext = await browser.createIncognitoBrowserContext();
+      const incognitoContext = await browser.createBrowserContext();
       const operationBatch = operations.slice(i, i + concurrency);
 
       const batchPromises = operationBatch.map(async (operation) => {

--- a/apps/nest-backend/src/waiter/datalayer/waiter-datalayer-group-events.service.ts
+++ b/apps/nest-backend/src/waiter/datalayer/waiter-datalayer-group-events.service.ts
@@ -26,7 +26,7 @@ export class WaiterDataLayerGroupEventsService {
   ) {
     // 3.1) inspect both dataLayer and the request sent to GA4
     const browser = await puppeteer.launch({
-      headless: headless === 'true' ? 'new' : false,
+      headless: headless === 'true' ? true : false,
       defaultViewport: null,
       ignoreHTTPSErrors: true,
       args: BROWSER_ARGS,

--- a/apps/nest-backend/src/waiter/datalayer/waiter-datalayer-single-event.service.ts
+++ b/apps/nest-backend/src/waiter/datalayer/waiter-datalayer-single-event.service.ts
@@ -18,9 +18,9 @@ export class WaiterDataLayerSingleEventService {
     inspectEventDto?: InspectEventDto
   ) {
     const browser = await puppeteer.launch({
-      headless: headless === 'true' ? 'new' : false,
+      headless: headless === 'true' ? true : false,
       defaultViewport: null,
-      // devtools: true,
+      devtools: measurementId ? true : false,
       ignoreHTTPSErrors: true,
       args:
         (inspectEventDto as any).inspectEventDto.puppeteerArgs || BROWSER_ARGS,

--- a/apps/nest-backend/src/web-agent/action/action-utils.ts
+++ b/apps/nest-backend/src/web-agent/action/action-utils.ts
@@ -122,7 +122,8 @@ function getElementByText(searchText) {
 }
 
 async function findElementByXPath(page: Page, xpath: string) {
-  const elements = await page.$x(xpath);
+  // TODO: deprecated page.$x; please handle it
+  const elements = await page.$$(xpath);
   if (elements.length > 0) {
     return elements[0]; // Assuming you want the first element found
   } else {

--- a/apps/nest-backend/src/web-agent/web-agent-utils.service.ts
+++ b/apps/nest-backend/src/web-agent/web-agent-utils.service.ts
@@ -22,7 +22,7 @@ export class WebAgentUtilsService {
     projectName: string,
     testName: string,
     filePath?: string,
-    captureRequest = false,
+    captureRequest?: boolean,
     measurementId?: string,
     credentials?: Credentials,
     application?: InspectEventDto['application']
@@ -61,6 +61,11 @@ export class WebAgentUtilsService {
           );
           eventRequest = interceptedRequest.url();
           page.off('request');
+        } else {
+          Logger.log(
+            interceptedRequest.url(),
+            'WebAgentUtils.performTest: monitoring request'
+          );
         }
       });
     }

--- a/apps/nest-backend/src/web-agent/web-agent.service.ts
+++ b/apps/nest-backend/src/web-agent/web-agent.service.ts
@@ -34,7 +34,7 @@ export class WebAgentService {
 
   async fetchDataLayer(url: string, credentials?: Credentials) {
     const browser = await puppeteer.launch({
-      headless: 'new',
+      headless: true,
       args: BROWSER_ARGS,
     });
 

--- a/apps/ng-frontend/src/app/shared/components/project-info-form/project-info-form.component.html
+++ b/apps/ng-frontend/src/app/shared/components/project-info-form/project-info-form.component.html
@@ -15,6 +15,10 @@
         <input matInput formControlName="projectName" />
       </mat-form-field>
       <mat-form-field class="project-info-form__field" appearance="outline">
+        <mat-label>Measurement ID</mat-label>
+        <input matInput formControlName="measurementId" />
+      </mat-form-field>
+      <mat-form-field class="project-info-form__field" appearance="outline">
         <mat-label>Project Description</mat-label>
         <textarea matInput formControlName="projectDescription"></textarea>
       </mat-form-field>

--- a/apps/ng-frontend/src/app/shared/components/project-info-form/project-info-form.component.ts
+++ b/apps/ng-frontend/src/app/shared/components/project-info-form/project-info-form.component.ts
@@ -38,9 +38,9 @@ export class ProjectInfoFormComponent implements OnInit, OnDestroy {
 
   projectInfoForm = this.fb.group({
     projectName: [''],
+    measurementId: [''],
     projectDescription: [''],
     googleSpreadsheetLink: [''],
-    preventNavigationEvents: this.fb.array([]),
   });
 
   constructor(
@@ -62,6 +62,7 @@ export class ProjectInfoFormComponent implements OnInit, OnDestroy {
             const settings = project.settings;
             this.projectInfoForm.patchValue({
               projectName: settings.projectName,
+              measurementId: settings.measurementId,
               projectDescription: settings.projectDescription,
               googleSpreadsheetLink: settings.googleSpreadsheetLink,
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "exceljs": "^4.3.0",
         "json-server": "^0.17.4",
         "nestjs-spelunker": "^1.1.5",
-        "puppeteer": "^21.4.0",
+        "puppeteer": "^22.6.1",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.0",
         "sequelize": "^6.35.2",
@@ -8784,15 +8784,16 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
-      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.0.tgz",
+      "integrity": "sha512-MC7LxpcBtdfTbzwARXIkqGZ1Osn3nnZJlm+i0+VqHl72t//Xwl9wICrXT8BwtgC6s1xJNHsxOpvzISUqe92+sw==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
         "progress": "2.0.3",
-        "proxy-agent": "6.3.1",
-        "tar-fs": "3.0.4",
+        "proxy-agent": "6.4.0",
+        "semver": "7.6.0",
+        "tar-fs": "3.0.5",
         "unbzip2-stream": "1.4.3",
         "yargs": "17.7.2"
       },
@@ -8800,8 +8801,38 @@
         "browsers": "lib/cjs/main-cli.js"
       },
       "engines": {
-        "node": ">=16.3.0"
+        "node": ">=18"
       }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.13.2",
@@ -11853,6 +11884,32 @@
       "integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==",
       "optional": true
     },
+    "node_modules/bare-fs": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.2.3.tgz",
+      "integrity": "sha512-amG72llr9pstfXOBOHve1WjiuKKAMnebcmMbPWDZ7BCevAoJLpugjuAPRsDINEyjT0a6tbaVx3DctkXIRbLuJw==",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-path": "^2.0.0",
+        "streamx": "^2.13.0"
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.2.1.tgz",
+      "integrity": "sha512-OwPyHgBBMkhC29Hl3O4/YfxW9n7mdTr2+SsO29XBWKKJsbgj3mnorDB80r5TiCQgQstgE5ga1qNYrpes6NvX2w==",
+      "optional": true
+    },
+    "node_modules/bare-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.1.tgz",
+      "integrity": "sha512-OHM+iwRDRMDBsSW7kl3dO62JyHdBKO3B25FB9vNQBPcGHMo4+eA8Yj41Lfbk3pS/seDY+siNge0LdRTulAau/A==",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^2.1.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -12554,12 +12611,13 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
-      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.14.tgz",
+      "integrity": "sha512-zm4mX61/U4KXs+S/0WIBHpOWqtpW6FPv1i7n4UZqDDc5LOQ9/Y1MAnB95nO7i/lFFuijLjpe1XMdNcqDqwlH5w==",
       "dependencies": {
         "mitt": "3.0.1",
-        "urlpattern-polyfill": "10.0.0"
+        "urlpattern-polyfill": "10.0.0",
+        "zod": "3.22.4"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -13456,14 +13514,6 @@
         "yarn": ">=1"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -14061,9 +14111,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1232444",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
-      "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg=="
+      "version": "0.0.1262051",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1262051.tgz",
+      "integrity": "sha512-YJe4CT5SA8on3Spa+UDtNhEqtuV6Epwz3OZ4HQVLhlRccpZ9/PAYk0/cy/oKxFKRrZPBUPyxympQci4yWNWZ9g=="
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -24519,14 +24569,14 @@
       }
     },
     "node_modules/proxy-agent": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
-      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.3",
         "lru-cache": "^7.14.1",
         "pac-proxy-agent": "^7.0.1",
         "proxy-from-env": "^1.1.0",
@@ -24543,6 +24593,18 @@
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
       },
       "engines": {
         "node": ">= 14"
@@ -24612,36 +24674,36 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.11.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.11.0.tgz",
-      "integrity": "sha512-9jTHuYe22TD3sNxy0nEIzC7ZrlRnDgeX3xPkbS7PnbdwYjl2o/z/YuCrRBwezdKpbTDTJ4VqIggzNyeRcKq3cg==",
+      "version": "22.6.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.6.1.tgz",
+      "integrity": "sha512-736QHNKtPD4tPeFbIn73E4l0CWsLzvRFlm0JsLG/VsyM8Eh0FRFNmMp+M3+GSMwdmYxqOVpTgzB6VQDxWxu8xQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "1.9.1",
+        "@puppeteer/browsers": "2.2.0",
         "cosmiconfig": "9.0.0",
-        "puppeteer-core": "21.11.0"
+        "devtools-protocol": "0.0.1262051",
+        "puppeteer-core": "22.6.1"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
       },
       "engines": {
-        "node": ">=16.13.2"
+        "node": ">=18"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.11.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
-      "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
+      "version": "22.6.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.1.tgz",
+      "integrity": "sha512-rShSd0xtyDSEJYys5nnzQnnwtrafQWg/lWCppyjZIIbYadWP8B1u0XJD/Oe+Xgw8v1hLHX0loNoA0ItRmNLnBg==",
       "dependencies": {
-        "@puppeteer/browsers": "1.9.1",
-        "chromium-bidi": "0.5.8",
-        "cross-fetch": "4.0.0",
+        "@puppeteer/browsers": "2.2.0",
+        "chromium-bidi": "0.5.14",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1232444",
+        "devtools-protocol": "0.0.1262051",
         "ws": "8.16.0"
       },
       "engines": {
-        "node": ">=16.13.2"
+        "node": ">=18"
       }
     },
     "node_modules/puppeteer/node_modules/cosmiconfig": {
@@ -27273,13 +27335,16 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
-      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
+      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
       "dependencies": {
-        "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^2.1.1",
+        "bare-path": "^2.1.0"
       }
     },
     "node_modules/tar-stream": {
@@ -29647,6 +29712,14 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zone.js": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@nestjs/testing": "^10.0.2",
     "@nx/angular": "17.2.8",
     "@nx/cypress": "17.2.8",
+    "@nx/eslint": "17.2.8",
     "@nx/eslint-plugin": "17.2.8",
     "@nx/jest": "17.2.8",
     "@nx/js": "17.2.8",
@@ -80,8 +81,7 @@
     "prettier": "^2.6.2",
     "ts-jest": "^29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "5.3.3",
-    "@nx/eslint": "17.2.8"
+    "typescript": "5.3.3"
   },
   "dependencies": {
     "@angular/animations": "~17.1.0",
@@ -114,7 +114,7 @@
     "exceljs": "^4.3.0",
     "json-server": "^0.17.4",
     "nestjs-spelunker": "^1.1.5",
-    "puppeteer": "^21.4.0",
+    "puppeteer": "^22.6.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.0",
     "sequelize": "^6.35.2",


### PR DESCRIPTION
1. At least one attempt to reconnect the preview mode to the target website.
2. Update Puppeteer version up to 22.6.1.
3. Adjust implementations according to Puppeteer.
4. Enable measement ID on the frontend.