### PR TITLE
fix: allow users to use chromium tool for testing.

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   packagerConfig: {
     asar: true,
+    unpack: '**/node_modules/puppeteer/.local-chromium/**/*',
     extraResource: [
       './dist/apps/ng-frontend',
       './dist/apps/nest-backend/main.js',


### PR DESCRIPTION
According to the [community](https://github.com/puppeteer/puppeteer/issues/2134), by stating the `unpack` option should allow users to open the testing browser.