### PR TITLE
feat: add JSON updates validators

### DIFF
--- a/apps/nest-backend/src/waiter/recording/waiter-recording.service.ts
+++ b/apps/nest-backend/src/waiter/recording/waiter-recording.service.ts
@@ -23,20 +23,27 @@ export class WaiterRecordingService {
         await this.folderPathService.getRecordingFolderPath(projectSlug)
       );
 
-      const recordings: RecordingDto = (await Promise.all(
+      const recordings = await Promise.all(
         folderNames.map(async (fileName) => {
-          return await this.fileService.readJsonFile(
+          const recordingContent = await this.fileService.readJsonFile(
             await this.filePathService.getRecordingFilePath(
               projectSlug,
               fileName
             )
           );
+          const key = fileName.replace('.json', '');
+          return { [key]: recordingContent };
         })
-      )) as any;
+      );
+
+      const flattenedRecordings: Record<string, RecordingDto> =
+        recordings.reduce((acc, recording) => {
+          return { ...acc, ...recording };
+        }, {});
 
       return {
         projectSlug: projectSlug,
-        recordings: recordings,
+        recordings: flattenedRecordings,
       };
     } catch (error) {
       if (error instanceof HttpException) {

--- a/apps/ng-frontend/src/app/modules/entry/views/home-view/home-view.component.ts
+++ b/apps/ng-frontend/src/app/modules/entry/views/home-view/home-view.component.ts
@@ -29,7 +29,6 @@ export class HomeViewComponent implements OnInit {
   constructor(private projectInfoService: ProjectInfoService) {}
 
   ngOnInit(): void {
-    console.log('HomeViewComponent initialized');
     this.projects$ = this.projectInfoService.getProjects();
   }
 }

--- a/apps/ng-frontend/src/app/modules/project/components/report-detail-panels/report-detail-panels.component.html
+++ b/apps/ng-frontend/src/app/modules/project/components/report-detail-panels/report-detail-panels.component.html
@@ -29,6 +29,7 @@
         <button
           mat-raised-button
           color="primary"
+          [disabled]="editorService.isJsonSyntaxError$ | async"
           (click)="onSpecUpdate(); switchSpecEditMode($event)"
         >
           Save
@@ -82,8 +83,13 @@
         ></app-editor>
         } @else {
         <!-- otherwise, showing the info -->
-        <pre class="json">{{ recording$ | async | json }}</pre>
-        }
+        @if (recording$ | async) {
+        <ng-container>
+          <pre class="json">{{ recording$ | async | json }}</pre>
+        </ng-container>
+        } @else {
+        <p>No recording found</p>
+        } }
       </mat-panel-description>
       @if (recordingEditMode) {
       <mat-action-row>
@@ -99,6 +105,7 @@
         <button
           mat-raised-button
           color="primary"
+          [disabled]="editorService.isJsonSyntaxError$ | async"
           (click)="onRecordingUpdate(); switchRecordingEditMode($event)"
         >
           Save

--- a/apps/ng-frontend/src/app/shared/services/api/recording/recording.service.ts
+++ b/apps/ng-frontend/src/app/shared/services/api/recording/recording.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Subject, catchError, of } from 'rxjs';
 import { ProjectRecording, Recording } from '@utils';
 import { environment } from '../../../../../environments/environment';
+import { UtilsService } from '../../utils/utils.service';
 
 @Injectable({
   providedIn: 'root',
@@ -13,7 +14,7 @@ export class RecordingService {
   );
   recording$ = this.recordingSubject.asObservable();
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private utilsService: UtilsService) {}
 
   getProjectRecordings(projectSlug: string) {
     return this.http
@@ -72,7 +73,11 @@ export class RecordingService {
     console.log('Project Slug', projectSlug);
     console.log('Event Id', eventId);
     console.log('Recording', jsonContent);
-    if (!eventId || !projectSlug || this.isEmptyObject(jsonContent))
+    if (
+      !eventId ||
+      !projectSlug ||
+      this.utilsService.isEmptyObject(jsonContent)
+    )
       return of(null);
     return this.http
       .post<Recording>(
@@ -85,32 +90,5 @@ export class RecordingService {
           return of(null);
         })
       );
-  }
-
-  private isEmptyObject(value: unknown): boolean {
-    if (value === null || value === undefined) {
-      return true;
-    }
-
-    if (typeof value !== 'object') {
-      return false;
-    }
-
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    }
-
-    if (value instanceof Date) {
-      return false;
-    }
-
-    if (value instanceof Set || value instanceof Map) {
-      return value.size === 0;
-    }
-
-    return (
-      Object.keys(value as object).length === 0 &&
-      Object.getOwnPropertySymbols(value as object).length === 0
-    );
   }
 }

--- a/apps/ng-frontend/src/app/shared/services/api/report/report.service.ts
+++ b/apps/ng-frontend/src/app/shared/services/api/report/report.service.ts
@@ -42,7 +42,7 @@ export class ReportService {
       .pipe(
         catchError((error) => {
           console.error(error);
-          return of([]);
+          return of(null);
         })
       );
   }

--- a/apps/ng-frontend/src/app/shared/services/editor/editor.service.ts
+++ b/apps/ng-frontend/src/app/shared/services/editor/editor.service.ts
@@ -24,15 +24,18 @@ export class EditorService {
     recordingJson: new BehaviorSubject(''),
   };
 
-  editorSubjects = {
+  editorViewSubjects = {
     specJson: new BehaviorSubject<EditorView>(new EditorView()),
     recordingJson: new BehaviorSubject<EditorView>(new EditorView()),
   };
 
   editor$ = {
-    specJsonEditor: this.editorSubjects.specJson.asObservable(),
-    recordingJsonEditor: this.editorSubjects.recordingJson.asObservable(),
+    specJsonEditor: this.editorViewSubjects.specJson.asObservable(),
+    recordingJsonEditor: this.editorViewSubjects.recordingJson.asObservable(),
   };
+
+  isJsonSyntaxError = new BehaviorSubject<boolean>(false);
+  isJsonSyntaxError$ = this.isJsonSyntaxError.asObservable();
 
   initEditorView(
     extension: EditorExtension,
@@ -46,6 +49,7 @@ export class EditorService {
         lintGutter(),
         EditorView.theme(editorStyles),
         EditorView.lineWrapping,
+        this.isEditorSyntaxError(),
         // placeholder(
         //   content ? content : this.contentSubjects[extension].getValue()
         // ),
@@ -61,18 +65,39 @@ export class EditorService {
       },
     });
 
-    this.editorSubjects[extension].next(editorView);
+    this.editorViewSubjects[extension].next(editorView);
   }
 
   setContent(extension: EditorExtension, content: string) {
     const jsonContent = JSON.stringify(JSON.parse(content), null, 2);
     this.contentSubjects[extension].next(jsonContent);
-    this.editorSubjects[extension].getValue().dispatch({
+    this.editorViewSubjects[extension].getValue().dispatch({
       changes: {
         from: 0,
         insert: jsonContent,
-        to: this.editorSubjects[extension].getValue().state.doc.length,
+        to: this.editorViewSubjects[extension].getValue().state.doc.length,
       },
     });
+  }
+
+  isEditorSyntaxError() {
+    return EditorView.updateListener.of((update) => {
+      if (update.docChanged) {
+        // Document has changed, you could trigger syntax checking here
+        console.log('Document has changed');
+        const isError = this.checkSyntax(update.state.doc.toString());
+        this.isJsonSyntaxError.next(isError);
+        console.log(this.isJsonSyntaxError.getValue());
+      }
+    });
+  }
+
+  private checkSyntax(content: string): boolean {
+    try {
+      JSON.parse(content);
+      return false;
+    } catch (error) {
+      return true;
+    }
   }
 }

--- a/apps/ng-frontend/src/app/shared/services/utils/utils.service.ts
+++ b/apps/ng-frontend/src/app/shared/services/utils/utils.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UtilsService {
+  isEmptyObject(value: unknown): boolean {
+    if (value === null || value === undefined || value === '') {
+      return true;
+    }
+    if (value === null || value === undefined) {
+      return true;
+    }
+
+    if (typeof value !== 'object') {
+      return false;
+    }
+
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    }
+
+    if (value instanceof Date) {
+      return false;
+    }
+
+    if (value instanceof Set || value instanceof Map) {
+      return value.size === 0;
+    }
+
+    return (
+      Object.keys(value as object).length === 0 &&
+      Object.getOwnPropertySymbols(value as object).length === 0
+    );
+  }
+
+  extractEventNameFromId(eventId: string) {
+    const eventName = eventId.replace(
+      /_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      ''
+    );
+    return eventName;
+  }
+}

--- a/libs/utils/src/lib/interfaces/recording.interface.ts
+++ b/libs/utils/src/lib/interfaces/recording.interface.ts
@@ -1,9 +1,9 @@
 export interface ProjectRecording {
   projectSlug: string;
-  recordings: Recording[];
+  recordings: Record<string, Recording>;
 }
 
 export interface Recording {
   title: string;
-  steps: any[];
+  steps: Record<string, any>[];
 }


### PR DESCRIPTION
1. Implementations prevent users from saving invalid JSON documents within the editor.
2. Re-implement algorithms to check whether test cases have the corresponding chrome recordings.
3. Create a utils service for frontend.
4. Remove redundant comments.
5. Improve types and interfaces.