### PR TITLE
feat: abort working Puppeteer

### DIFF
--- a/apps/nest-backend/src/inspector/inspector-single-event.service.ts
+++ b/apps/nest-backend/src/inspector/inspector-single-event.service.ts
@@ -72,17 +72,26 @@ export class InspectorSingleEventService {
             expectedObj
           );
 
-          Logger.log(dataLayerResult, 'inspector.inspectDataLayer');
+          Logger.log(
+            dataLayerResult,
+            'InspectorSingleEventService.inspectDataLayer'
+          );
 
           const destinationUrl = result.destinationUrl;
-          Logger.log(destinationUrl, 'inspector.inspectDataLayer');
+          Logger.log(
+            destinationUrl,
+            'InspectorSingleEventService.inspectDataLayer'
+          );
           await this.fileService.writeCacheFile(projectName, eventId, result);
           await page.screenshot({
             path: imageSavingFolder,
           });
 
           if (headless === 'true') await page.close();
-          Logger.log('Browser is closed!', 'inspector.inspectDataLayer');
+          Logger.log(
+            'Browser is closed!',
+            'InspectorSingleEventService.inspectDataLayer'
+          );
           return {
             dataLayerResult,
             destinationUrl,
@@ -140,7 +149,10 @@ export class InspectorSingleEventService {
         }
       }
     } catch (error) {
-      Logger.error(error.message, 'inspector.inspectDataLayer');
+      Logger.error(
+        error.message,
+        'InspectorSingleEventService.inspectDataLayer'
+      );
       throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }

--- a/apps/nest-backend/src/pipeline/pipeline.service.ts
+++ b/apps/nest-backend/src/pipeline/pipeline.service.ts
@@ -80,10 +80,15 @@ export class PipelineService {
         eventId,
         outputValidationResult
       );
+
+      await page.close();
       return data;
     } catch (error) {
-      Logger.log(error.message, 'PipelineService.singleEventInspectionRecipe');
-      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+      Logger.error(
+        error.message,
+        'PipelineService.singleEventInspectionRecipe'
+      );
+      // throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/apps/nest-backend/src/waiter/datalayer/waiter-datalayer-single-event.service.ts
+++ b/apps/nest-backend/src/waiter/datalayer/waiter-datalayer-single-event.service.ts
@@ -1,11 +1,14 @@
 import { EventInspectionPresetDto } from '../../dto/event-inspection-preset.dto';
 import { Injectable, Logger } from '@nestjs/common';
-import { Credentials } from 'puppeteer';
+import { Browser, Credentials, Page } from 'puppeteer';
 import { BROWSER_ARGS } from '../../configs/project.config';
 import { PipelineService } from '../../pipeline/pipeline.service';
 @Injectable()
 export class WaiterDataLayerSingleEventService {
   constructor(private pipelineService: PipelineService) {}
+  private abortController: AbortController | null = null;
+  private currentBrowser: Browser | null = null;
+  private currentPage: Page | null = null;
 
   async inspectSingleEvent(
     projectName: string,
@@ -15,33 +18,75 @@ export class WaiterDataLayerSingleEventService {
     credentials?: Credentials,
     eventInspectionPresetDto?: EventInspectionPresetDto
   ) {
+    this.abortController = new AbortController();
+    const { signal } = this.abortController;
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const PCR = require('puppeteer-chromium-resolver');
     const options = {};
     const stats = await PCR(options);
-    Logger.log(
-      stats,
-      'WaiterDataLayerSingleEventService.inspectSingleEvent: stats'
-    );
-    const browser = await stats.puppeteer.launch({
-      headless: headless === 'true' ? true : false,
-      defaultViewport: null,
-      devtools: measurementId ? true : false,
-      ignoreHTTPSErrors: true,
-      args: eventInspectionPresetDto.puppeteerArgs || BROWSER_ARGS,
-      executablePath: stats.executablePath,
-    });
-    Logger.log('Browser launched', 'waiter.inspectSingleEvent');
-    const [page] = await browser.pages();
+    try {
+      this.currentBrowser = await stats.puppeteer.launch({
+        headless: headless === 'true' ? true : false,
+        defaultViewport: null,
+        devtools: measurementId ? true : false,
+        ignoreHTTPSErrors: true,
+        args: eventInspectionPresetDto.puppeteerArgs || BROWSER_ARGS,
+        executablePath: stats.executablePath,
+        signal: signal,
+      });
+      Logger.log('Browser launched', 'waiter.inspectSingleEvent');
 
-    return this.pipelineService.singleEventInspectionRecipe(
-      page,
-      projectName,
-      eventId,
-      headless,
-      measurementId,
-      credentials,
-      eventInspectionPresetDto
-    );
+      this.currentPage = (await this.currentBrowser.pages())[0];
+
+      // Set up an abort listener
+      signal.addEventListener(
+        'abort',
+        async () => {
+          await this.cleanup();
+        },
+        { once: true }
+      );
+
+      return await this.pipelineService.singleEventInspectionRecipe(
+        this.currentPage,
+        projectName,
+        eventId,
+        headless,
+        measurementId,
+        credentials,
+        eventInspectionPresetDto
+      );
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        Logger.log('Operation was aborted', 'waiter.inspectSingleEvent');
+      } else {
+        Logger.error(error, 'waiter.inspectSingleEvent');
+      }
+      await this.cleanup();
+      throw error;
+    }
+  }
+
+  stopOperation() {
+    Logger.log('Operation stopped', 'waiter.inspectSingleEvent');
+    if (this.abortController) {
+      this.abortController.abort();
+    }
+  }
+
+  private async cleanup() {
+    Logger.log('Cleaning up resources', 'waiter.inspectSingleEvent');
+    if (this.currentPage) {
+      await this.currentPage
+        .close()
+        .catch((err) => Logger.error(err, 'Error closing page'));
+      this.currentPage = null;
+    }
+    if (this.currentBrowser) {
+      await this.currentBrowser
+        .close()
+        .catch((err) => Logger.error(err, 'Error closing browser'));
+      this.currentBrowser = null;
+    }
   }
 }

--- a/apps/nest-backend/src/waiter/datalayer/waiter-datalayer.controller.ts
+++ b/apps/nest-backend/src/waiter/datalayer/waiter-datalayer.controller.ts
@@ -132,4 +132,24 @@ export class WaiterDataLayerController {
       Number(concurrency)
     );
   }
+
+  @Post('stop-operation')
+  @ApiOperation({
+    summary: 'Stops the current operation',
+    description:
+      'This endpoint stops the current operation and returns the results of the operation.',
+  })
+  @ApiResponse({ status: 200, description: 'Operation stopped successfully.' })
+  stopOperation() {
+    try {
+      this.waiterDataLayerSingleEventService.stopOperation();
+      return { message: 'Operation stopped successfully' };
+    } catch (error) {
+      Logger.error(error, 'waiter.stopOperation');
+      throw new HttpException(
+        'Failed to stop operation',
+        HttpStatus.INTERNAL_SERVER_ERROR
+      );
+    }
+  }
 }

--- a/apps/nest-backend/src/waiter/gtm-operator/waiter-gtm-operator.controller.ts
+++ b/apps/nest-backend/src/waiter/gtm-operator/waiter-gtm-operator.controller.ts
@@ -1,5 +1,14 @@
 import { ApiOperation, ApiParam, ApiQuery, ApiResponse } from '@nestjs/swagger';
-import { Body, Controller, Logger, Param, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  HttpException,
+  HttpStatus,
+  Logger,
+  Param,
+  Post,
+  Query,
+} from '@nestjs/common';
 import { WaiterGtmOperatorService } from './waiter-gtm-operator.service';
 import { ValidationResult, EventInspectionPresetDto } from '@utils';
 import { AbstractReportService } from '../../os/abstract-report/abstract-report.service';
@@ -81,5 +90,25 @@ export class WaiterGtmOperatorController {
         eventName
       );
     return [abstractReport];
+  }
+
+  @Post('stop-operation')
+  @ApiOperation({
+    summary: 'Stops the current operation',
+    description:
+      'This endpoint stops the current operation and returns the results of the operation.',
+  })
+  @ApiResponse({ status: 200, description: 'Operation stopped successfully.' })
+  stopOperation() {
+    try {
+      this.waiterGtmOperatorService.stopOperation();
+      return { message: 'Operation stopped successfully' };
+    } catch (error) {
+      Logger.error(error, 'waiter.stopOperation');
+      throw new HttpException(
+        'Failed to stop operation',
+        HttpStatus.INTERNAL_SERVER_ERROR
+      );
+    }
   }
 }

--- a/apps/nest-backend/src/waiter/gtm-operator/waiter-gtm-operator.service.ts
+++ b/apps/nest-backend/src/waiter/gtm-operator/waiter-gtm-operator.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { GtmOperatorService } from '../../gtm-operator/gtm-operator.service';
 import { Credentials } from 'puppeteer';
 import { EventInspectionPresetDto } from '../../dto/event-inspection-preset.dto';
@@ -24,5 +24,10 @@ export class WaiterGtmOperatorService {
       credentials,
       eventInspectionPresetDto
     );
+  }
+
+  stopOperation() {
+    Logger.log('Operation stopped', 'WaiterGtmOperatorService');
+    return this.gtmOperatorService.stopOperation();
   }
 }

--- a/apps/ng-frontend/src/app/modules/project/components/report-table-toolbar/report-table-toolbar.component.html
+++ b/apps/ng-frontend/src/app/modules/project/components/report-table-toolbar/report-table-toolbar.component.html
@@ -29,6 +29,16 @@
   >
     <mat-icon>bookmark_border</mat-icon>
   </button>
+  <button
+    mat-icon-button
+    class="icon"
+    matTooltip="Mark to stop operation for this event"
+    matTooltipPosition="above"
+    aria-label="Stop operation"
+    (click)="stopOperation()"
+  >
+    <mat-icon>cancel</mat-icon>
+  </button>
   <div class="spacer"></div>
   @if (!isSearchVisible) {
   <mat-button-toggle-group

--- a/apps/ng-frontend/src/app/modules/project/components/report-table/report-table.component.html
+++ b/apps/ng-frontend/src/app/modules/project/components/report-table/report-table.component.html
@@ -82,7 +82,7 @@
       </th>
       <td mat-cell *matCellDef="let element">
         <!-- running a test -->
-        @if ((testRunningFacadeService.isRunningTest$ | async)) { @if
+        @if ((testRunningFacadeService.isRunningTest$ | async) === true) { @if
         ((testRunningFacadeService.eventRunningTest$ | async) ===
         element.eventId) {
         <mat-progress-spinner

--- a/apps/ng-frontend/src/app/shared/services/api/datalayer/datalayer.service.ts
+++ b/apps/ng-frontend/src/app/shared/services/api/datalayer/datalayer.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../../environments/environment';
 import { EventInspectionPreset } from '@utils';
-import { catchError, of } from 'rxjs';
+import { catchError, map, Observable, of } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -33,6 +33,18 @@ export class DataLayerService {
         catchError((error) => {
           console.error(error);
           return of(null);
+        })
+      );
+  }
+
+  stopOperation(): Observable<string> {
+    return this.http
+      .post<string>(`${environment.dataLayerApiUrl}/stop-operation`, {})
+      .pipe(
+        map((message) => message),
+        catchError((error) => {
+          console.error('Error stopping operation:', error);
+          throw error;
         })
       );
   }

--- a/apps/ng-frontend/src/app/shared/services/api/gtm-operator/gtm-operator.service.ts
+++ b/apps/ng-frontend/src/app/shared/services/api/gtm-operator/gtm-operator.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../../environments/environment';
 import { EventInspectionPreset } from '@utils';
-import { catchError, of } from 'rxjs';
+import { catchError, map, Observable, of, tap } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -39,6 +39,18 @@ export class GtmOperatorService {
         catchError((error) => {
           console.error(error);
           return of(null);
+        })
+      );
+  }
+
+  stopOperation(): Observable<string> {
+    return this.http
+      .post<string>(`${environment.dataLayerApiUrl}/stop-operation`, {})
+      .pipe(
+        map((message) => message),
+        catchError((error) => {
+          console.error('Error stopping operation:', error);
+          throw error;
         })
       );
   }

--- a/apps/ng-frontend/src/app/shared/services/api/qa-request/qa-request.service.ts
+++ b/apps/ng-frontend/src/app/shared/services/api/qa-request/qa-request.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../../environments/environment';
 import { EventInspectionPreset } from '@utils';
-import { catchError, of } from 'rxjs';
+import { catchError, map, Observable, of, tap } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -34,6 +34,18 @@ export class QaRequestService {
         catchError((error) => {
           console.error(error);
           return of(null);
+        })
+      );
+  }
+
+  stopOperation(): Observable<string> {
+    return this.http
+      .post<string>(`${environment.dataLayerApiUrl}/stop-operation`, {})
+      .pipe(
+        map((message) => message),
+        catchError((error) => {
+          console.error('Error stopping operation:', error);
+          throw error;
         })
       );
   }


### PR DESCRIPTION
1. Add AbortController and its listener to abort running Puppeteer operations.
2. Close Puppeteer pages and browsers after aborting operations.
3. Update endpoints and Angular UI accordingly.