### PR TITLE
fix: reload behavior and reactive data updates

### DIFF
--- a/apps/nest-backend/src/web-agent/action/step-executor-utils.ts
+++ b/apps/nest-backend/src/web-agent/action/step-executor-utils.ts
@@ -48,6 +48,7 @@ export async function handleNavigate(
 ) {
   try {
     await page.goto(step.url);
+    const finalUrl = page.url();
 
     await sleep(1000); // Necessary delay for the website to update
     // pre-load the application localStorage if any
@@ -80,7 +81,12 @@ export async function handleNavigate(
     // try to skip the overlay or popups
     if (state.isFirstNavigation) {
       // only reload the landing page, trying to skip the overlay
-      await page.reload();
+      // Reload the page with the final URL to apply localStorage and cookies
+      Logger.log(
+        `Reload the page with the final URL ${finalUrl}`,
+        'StepExecutor.handleNavigate'
+      );
+      await page.goto(finalUrl);
       await sleep(1000); // Necessary delay for the website to update
       state.isFirstNavigation = false;
     }

--- a/apps/ng-frontend/src/app/modules/project/components/report-table/report-table.component.ts
+++ b/apps/ng-frontend/src/app/modules/project/components/report-table/report-table.component.ts
@@ -145,15 +145,19 @@ export class ReportTableComponent implements AfterViewInit, OnDestroy {
     this.route.params
       .pipe(
         take(1),
-        tap((params: Params) => {
-          this.testRunningFacadeService.runTest(
+        switchMap((params: Params) => {
+          return this.testRunningFacadeService.runTest(
             eventId,
             params['projectSlug'],
             this.testDataSource
           );
         })
       )
-      .subscribe();
+      .subscribe((updatedData) => {
+        if (updatedData) {
+          this.testDataSource.data = [...updatedData.data];
+        }
+      });
   }
 
   selectSingleRow(row: IReportDetails) {

--- a/apps/ng-frontend/src/app/shared/services/project-data-source/project-data-source.service.ts
+++ b/apps/ng-frontend/src/app/shared/services/project-data-source/project-data-source.service.ts
@@ -7,7 +7,7 @@ import { Injectable } from '@angular/core';
   providedIn: 'root',
 })
 export class ProjectDataSourceService extends DataSource<IReportDetails> {
-  private _dataStream = new ReplaySubject<IReportDetails[]>();
+  private _dataStream = new BehaviorSubject<IReportDetails[]>([]);
   private _filterStream = new ReplaySubject<string>();
   private _deletedStream = new BehaviorSubject<boolean>(false);
   private _preventNavigationStream = new ReplaySubject<boolean>();


### PR DESCRIPTION
1. Use page.goto() instead of page.reload() to reload the original URL, not redirected URL.
2. Fix implementation in Angular to update the data source properly.