### PR TITLE
fix: adjust Puppeteer viewport to be smaller

### DIFF
--- a/apps/nest-backend/src/web-agent/puppeteer-utils/puppeteer-utils.module.ts
+++ b/apps/nest-backend/src/web-agent/puppeteer-utils/puppeteer-utils.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { PuppeteerUtilsService } from './puppeteer-utils.service';
-
+import { FilePathService } from '../../os/path/file-path/file-path.service';
+import { OsModule } from '../../os/os.module';
 @Module({
-  imports: [],
-  providers: [PuppeteerUtilsService],
+  imports: [OsModule],
+  providers: [PuppeteerUtilsService, FilePathService],
   exports: [PuppeteerUtilsService],
 })
 export class PuppeteerUtilsModule {}


### PR DESCRIPTION
1. Add an extra file to extract viewport width and height; might verify the issue that assigning variables lead to errors.
2. Adjust module and provider.