### PR TITLE
[codex] tighten tag-build contracts

### DIFF
--- a/apps/nest-backend/src/features/example-project/events/add-payment-info.ts
+++ b/apps/nest-backend/src/features/example-project/events/add-payment-info.ts
@@ -1,5 +1,6 @@
-import { ItemDef, Recording, Spec, TagConfig, TriggerConfig } from '@utils';
+import { ItemDef, Recording } from '@utils';
 import { exampleGtmJson } from '../gtm-json';
+import { buildExampleEventSpec } from './helpers';
 
 const EVENT_NAME = 'add_payment_info';
 
@@ -57,24 +58,8 @@ const recording: Recording = {
   ]
 };
 
-const tag = exampleGtmJson.containerVersion.tag.find(
-  (t) => t.parameter.find((p) => p.key === 'eventName')?.value === EVENT_NAME
-);
-if (!tag) {
-  throw new Error(
-    `Tag with eventName "${EVENT_NAME}" not found in exampleGtmJson`
-  );
-}
-const normalizedTag: TagConfig = tag;
-
-const triggerNormalized = exampleGtmJson.containerVersion.trigger.find(
-  (t) => t.triggerId && (tag.firingTriggerId || []).includes(t.triggerId)
-) as unknown as TriggerConfig | undefined;
-
-const spec: Spec = {
-  tag: normalizedTag,
-  trigger: triggerNormalized ? [triggerNormalized] : []
-};
+const spec = buildExampleEventSpec(exampleGtmJson, EVENT_NAME);
+const normalizedTag = spec.tag;
 
 const fullItemDef: ItemDef = {
   templateName: 'Payment Info Items',

--- a/apps/nest-backend/src/features/example-project/events/add-shipping-info.ts
+++ b/apps/nest-backend/src/features/example-project/events/add-shipping-info.ts
@@ -1,5 +1,6 @@
-import { ItemDef, Recording, Spec, TagConfig, TriggerConfig } from '@utils';
+import { ItemDef, Recording } from '@utils';
 import { exampleGtmJson } from '../gtm-json';
+import { buildExampleEventSpec } from './helpers';
 
 const EVENT_NAME = 'add_shipping_info';
 
@@ -64,24 +65,8 @@ const recording: Recording = {
   ]
 };
 
-const tag = exampleGtmJson.containerVersion.tag.find(
-  (t) => t.parameter.find((p) => p.key === 'eventName')?.value === EVENT_NAME
-);
-if (!tag) {
-  throw new Error(
-    'Tag with eventName "add_shipping_info" not found in exampleGtmJson'
-  );
-}
-const normalizedTag: TagConfig = tag;
-
-const triggerNormalized = exampleGtmJson.containerVersion.trigger.find(
-  (t) => t.triggerId && (tag.firingTriggerId || []).includes(t.triggerId)
-) as unknown as TriggerConfig | undefined;
-
-const spec: Spec = {
-  tag: normalizedTag,
-  trigger: triggerNormalized ? [triggerNormalized] : []
-};
+const spec = buildExampleEventSpec(exampleGtmJson, EVENT_NAME);
+const normalizedTag = spec.tag;
 
 const fullItemDef: ItemDef = {
   templateName: 'Shipping Info Items',

--- a/apps/nest-backend/src/features/example-project/events/add-to-cart.ts
+++ b/apps/nest-backend/src/features/example-project/events/add-to-cart.ts
@@ -1,5 +1,6 @@
-import { ItemDef, Recording, Spec, TagConfig, TriggerConfig } from '@utils';
+import { ItemDef, Recording } from '@utils';
 import { exampleGtmJson } from '../gtm-json';
+import { buildExampleEventSpec } from './helpers';
 
 const recording: Recording = {
   title: 'add_to_cart',
@@ -41,24 +42,8 @@ const recording: Recording = {
   ]
 };
 
-const tag = exampleGtmJson.containerVersion.tag.find(
-  (t) => t.parameter.find((p) => p.key === 'eventName')?.value === 'add_to_cart'
-);
-if (!tag) {
-  throw new Error(
-    'Tag with eventName "add_to_cart" not found in exampleGtmJson'
-  );
-}
-const normalizedTag: TagConfig = tag;
-
-const triggerNormalized = exampleGtmJson.containerVersion.trigger.find(
-  (t) => t.triggerId && (tag.firingTriggerId || []).includes(t.triggerId)
-) as unknown as TriggerConfig | undefined;
-
-const spec: Spec = {
-  tag: normalizedTag,
-  trigger: triggerNormalized ? [triggerNormalized] : []
-};
+const spec = buildExampleEventSpec(exampleGtmJson, 'add_to_cart');
+const normalizedTag = spec.tag;
 
 const fullItemDef: ItemDef = {
   templateName: 'Add to cart Info Items',

--- a/apps/nest-backend/src/features/example-project/events/begin-checkout.ts
+++ b/apps/nest-backend/src/features/example-project/events/begin-checkout.ts
@@ -1,5 +1,6 @@
-import { ItemDef, Recording, Spec, TagConfig, TriggerConfig } from '@utils';
+import { ItemDef, Recording } from '@utils';
 import { exampleGtmJson } from '../gtm-json';
+import { buildExampleEventSpec } from './helpers';
 
 const recording: Recording = {
   title: 'begin_checkout',
@@ -55,25 +56,8 @@ const recording: Recording = {
   ]
 };
 
-const tag = exampleGtmJson.containerVersion.tag.find(
-  (t) =>
-    t.parameter.find((p) => p.key === 'eventName')?.value === 'begin_checkout'
-);
-if (!tag) {
-  throw new Error(
-    'Tag with eventName "begin_checkout" not found in exampleGtmJson'
-  );
-}
-const normalizedTag: TagConfig = tag;
-
-const triggerNormalized = exampleGtmJson.containerVersion.trigger.find(
-  (t) => t.triggerId && (tag.firingTriggerId || []).includes(t.triggerId)
-) as unknown as TriggerConfig | undefined;
-
-const spec: Spec = {
-  tag: normalizedTag,
-  trigger: triggerNormalized ? [triggerNormalized] : []
-};
+const spec = buildExampleEventSpec(exampleGtmJson, 'begin_checkout');
+const normalizedTag = spec.tag;
 
 const fullItemDef: ItemDef = {
   templateName: 'Begin Checkout Info Items',

--- a/apps/nest-backend/src/features/example-project/events/helpers.ts
+++ b/apps/nest-backend/src/features/example-project/events/helpers.ts
@@ -1,0 +1,42 @@
+import {
+  GTMConfiguration,
+  Spec,
+  TriggerConfig,
+  getParameterValue
+} from '@utils';
+
+function findTriggersByIds(
+  triggers: TriggerConfig[],
+  firingTriggerIds: string[]
+): TriggerConfig[] {
+  const triggerIds = new Set(firingTriggerIds);
+
+  return triggers.filter(
+    (trigger) =>
+      typeof trigger.triggerId === 'string' && triggerIds.has(trigger.triggerId)
+  );
+}
+
+export function buildExampleEventSpec(
+  configuration: GTMConfiguration,
+  eventName: string
+): Spec {
+  const tag = configuration.containerVersion.tag.find(
+    (candidate) =>
+      getParameterValue(candidate.parameter, 'eventName') === eventName
+  );
+
+  if (!tag) {
+    throw new Error(
+      `Tag with eventName "${eventName}" not found in exampleGtmJson`
+    );
+  }
+
+  return {
+    tag,
+    trigger: findTriggersByIds(
+      configuration.containerVersion.trigger,
+      tag.firingTriggerId ?? []
+    )
+  };
+}

--- a/apps/nest-backend/src/features/example-project/events/page-view.ts
+++ b/apps/nest-backend/src/features/example-project/events/page-view.ts
@@ -1,5 +1,6 @@
-import { Recording, Spec, TagConfig, TriggerConfig } from '@utils';
+import { Recording } from '@utils';
 import { exampleGtmJson } from '../gtm-json';
+import { buildExampleEventSpec } from './helpers';
 
 const EVENT_NAME = 'page_view';
 
@@ -29,22 +30,8 @@ const pageViewRecording: Recording = {
   ]
 };
 
-const tag = exampleGtmJson.containerVersion.tag.find(
-  (t) => t.parameter.find((p) => p.key === 'eventName')?.value === EVENT_NAME
-);
-if (!tag) {
-  throw new Error('Tag with eventName "page_view" not found in exampleGtmJson');
-}
-const normalizedTag: TagConfig = tag;
-
-const triggerNormalized = exampleGtmJson.containerVersion.trigger.find(
-  (t) => t.triggerId && (tag.firingTriggerId || []).includes(t.triggerId)
-) as unknown as TriggerConfig | undefined;
-
-const spec: Spec = {
-  tag: normalizedTag,
-  trigger: triggerNormalized ? [triggerNormalized] : []
-};
+const spec = buildExampleEventSpec(exampleGtmJson, EVENT_NAME);
+const normalizedTag = spec.tag;
 
 export const pageViewExample = {
   eventName: EVENT_NAME,

--- a/apps/nest-backend/src/features/example-project/events/purchase.ts
+++ b/apps/nest-backend/src/features/example-project/events/purchase.ts
@@ -1,5 +1,6 @@
-import { ItemDef, Recording, Spec, TagConfig, TriggerConfig } from '@utils';
+import { ItemDef, Recording } from '@utils';
 import { exampleGtmJson } from '../gtm-json';
+import { buildExampleEventSpec } from './helpers';
 
 const EVENT_NAME = 'purchase';
 
@@ -78,24 +79,8 @@ const recording: Recording = {
   ]
 };
 
-const tag = exampleGtmJson.containerVersion.tag.find(
-  (t) => t.parameter.find((p) => p.key === 'eventName')?.value === EVENT_NAME
-);
-if (!tag) {
-  throw new Error(
-    `Tag with eventName "${EVENT_NAME}" not found in exampleGtmJson`
-  );
-}
-const normalizedTag: TagConfig = tag;
-
-const triggerNormalized = exampleGtmJson.containerVersion.trigger.find(
-  (t) => t.triggerId && (tag.firingTriggerId || []).includes(t.triggerId)
-) as unknown as TriggerConfig | undefined;
-
-const spec: Spec = {
-  tag: normalizedTag,
-  trigger: triggerNormalized ? [triggerNormalized] : []
-};
+const spec = buildExampleEventSpec(exampleGtmJson, EVENT_NAME);
+const normalizedTag = spec.tag;
 
 const fullItemDef: ItemDef = {
   templateName: 'Purchase Info Items',

--- a/apps/nest-backend/src/features/example-project/events/refund.ts
+++ b/apps/nest-backend/src/features/example-project/events/refund.ts
@@ -1,5 +1,6 @@
-import { Recording, Spec, TagConfig, TriggerConfig } from '@utils';
+import { Recording } from '@utils';
 import { exampleGtmJson } from '../gtm-json';
+import { buildExampleEventSpec } from './helpers';
 
 const recording: Recording = {
   title: 'refund',
@@ -76,22 +77,8 @@ const recording: Recording = {
   ]
 };
 
-const tag = exampleGtmJson.containerVersion.tag.find(
-  (t) => t.parameter.find((p) => p.key === 'eventName')?.value === 'refund'
-);
-if (!tag) {
-  throw new Error('Tag with eventName "refund" not found in exampleGtmJson');
-}
-const normalizedTag: TagConfig = tag;
-
-const triggerNormalized = exampleGtmJson.containerVersion.trigger.find(
-  (t) => t.triggerId && (tag.firingTriggerId || []).includes(t.triggerId)
-) as unknown as TriggerConfig | undefined;
-
-const spec: Spec = {
-  tag: normalizedTag,
-  trigger: triggerNormalized ? [triggerNormalized] : []
-};
+const spec = buildExampleEventSpec(exampleGtmJson, 'refund');
+const normalizedTag = spec.tag;
 
 export const refundExample = {
   eventName: 'refund',

--- a/apps/nest-backend/src/features/example-project/events/select-promotion.ts
+++ b/apps/nest-backend/src/features/example-project/events/select-promotion.ts
@@ -1,5 +1,6 @@
-import { ItemDef, Recording, Spec, TagConfig, TriggerConfig } from '@utils';
+import { ItemDef, Recording } from '@utils';
 import { exampleGtmJson } from '../gtm-json';
+import { buildExampleEventSpec } from './helpers';
 
 const EVENT_NAME = 'select_promotion';
 
@@ -36,24 +37,8 @@ const recording: Recording = {
   ]
 };
 
-const tag = exampleGtmJson.containerVersion.tag.find(
-  (t) => t.parameter.find((p) => p.key === 'eventName')?.value === EVENT_NAME
-);
-if (!tag) {
-  throw new Error(
-    `Tag with eventName "${EVENT_NAME}" not found in exampleGtmJson`
-  );
-}
-const normalizedTag: TagConfig = tag;
-
-const triggerNormalized = exampleGtmJson.containerVersion.trigger.find(
-  (t) => t.triggerId && (tag.firingTriggerId || []).includes(t.triggerId)
-) as unknown as TriggerConfig | undefined;
-
-const spec: Spec = {
-  tag: normalizedTag,
-  trigger: triggerNormalized ? [triggerNormalized] : []
-};
+const spec = buildExampleEventSpec(exampleGtmJson, EVENT_NAME);
+const normalizedTag = spec.tag;
 
 const fullItemDef: ItemDef = {
   templateName: 'Select Promotion Info Items',

--- a/apps/nest-backend/src/features/example-project/events/view-cart.ts
+++ b/apps/nest-backend/src/features/example-project/events/view-cart.ts
@@ -1,5 +1,6 @@
-import { Recording, Spec, TagConfig, TriggerConfig } from '@utils';
+import { Recording } from '@utils';
 import { exampleGtmJson } from '../gtm-json';
+import { buildExampleEventSpec } from './helpers';
 
 const VIEW_CART = 'view_cart';
 
@@ -50,24 +51,8 @@ const recording: Recording = {
   ]
 };
 
-const tag = exampleGtmJson.containerVersion.tag.find(
-  (t) => t.parameter.find((p) => p.key === 'eventName')?.value === VIEW_CART
-);
-if (!tag) {
-  throw new Error(
-    `Tag with eventName "${VIEW_CART}" not found in exampleGtmJson`
-  );
-}
-const normalizedTag: TagConfig = tag;
-
-const triggerNormalized = exampleGtmJson.containerVersion.trigger.find(
-  (t) => t.triggerId && (tag.firingTriggerId || []).includes(t.triggerId)
-) as unknown as TriggerConfig | undefined;
-
-const spec: Spec = {
-  tag: normalizedTag,
-  trigger: triggerNormalized ? [triggerNormalized] : []
-};
+const spec = buildExampleEventSpec(exampleGtmJson, VIEW_CART);
+const normalizedTag = spec.tag;
 
 export const viewCartExample = {
   eventName: VIEW_CART,

--- a/apps/nest-backend/src/features/example-project/events/view-item-list.ts
+++ b/apps/nest-backend/src/features/example-project/events/view-item-list.ts
@@ -1,5 +1,6 @@
-import { Recording, Spec, TagConfig, TriggerConfig } from '@utils';
+import { Recording } from '@utils';
 import { exampleGtmJson } from '../gtm-json';
+import { buildExampleEventSpec } from './helpers';
 
 const EVENT_NAME = 'view_item_list';
 
@@ -36,24 +37,8 @@ const recording: Recording = {
   ]
 };
 
-const tag = exampleGtmJson.containerVersion.tag.find(
-  (t) => t.parameter.find((p) => p.key === 'eventName')?.value === EVENT_NAME
-);
-if (!tag) {
-  throw new Error(
-    `Tag with eventName "${EVENT_NAME}" not found in exampleGtmJson`
-  );
-}
-const normalizedTag: TagConfig = tag;
-
-const triggerNormalized = exampleGtmJson.containerVersion.trigger.find(
-  (t) => t.triggerId && (tag.firingTriggerId || []).includes(t.triggerId)
-) as unknown as TriggerConfig | undefined;
-
-const spec: Spec = {
-  tag: normalizedTag,
-  trigger: triggerNormalized ? [triggerNormalized] : []
-};
+const spec = buildExampleEventSpec(exampleGtmJson, EVENT_NAME);
+const normalizedTag = spec.tag;
 
 export const viewItemListExample = {
   eventName: EVENT_NAME,

--- a/apps/nest-backend/src/features/example-project/events/view-item.ts
+++ b/apps/nest-backend/src/features/example-project/events/view-item.ts
@@ -1,5 +1,6 @@
-import { Recording, Spec, TagConfig, TriggerConfig } from '@utils';
+import { Recording } from '@utils';
 import { exampleGtmJson } from '../gtm-json';
+import { buildExampleEventSpec } from './helpers';
 
 const EVENT_NAME = 'view_item';
 
@@ -36,24 +37,8 @@ const viewItemRecording: Recording = {
   ]
 };
 
-const tag = exampleGtmJson.containerVersion.tag.find(
-  (t) => t.parameter.find((p) => p.key === 'eventName')?.value === EVENT_NAME
-);
-if (!tag) {
-  throw new Error(
-    `Tag with eventName "${EVENT_NAME}" not found in exampleGtmJson`
-  );
-}
-const normalizedTag: TagConfig = tag;
-
-const triggerNormalized = exampleGtmJson.containerVersion.trigger.find(
-  (t) => t.triggerId && (tag.firingTriggerId || []).includes(t.triggerId)
-) as unknown as TriggerConfig | undefined;
-
-const spec: Spec = {
-  tag: normalizedTag,
-  trigger: triggerNormalized ? [triggerNormalized] : []
-};
+const spec = buildExampleEventSpec(exampleGtmJson, EVENT_NAME);
+const normalizedTag = spec.tag;
 
 export const viewItemExample = {
   recording: viewItemRecording,

--- a/apps/nest-backend/src/features/example-project/events/view-promotion.ts
+++ b/apps/nest-backend/src/features/example-project/events/view-promotion.ts
@@ -1,5 +1,6 @@
-import { Recording, Spec, TagConfig, TriggerConfig } from '@utils';
+import { Recording } from '@utils';
 import { exampleGtmJson } from '../gtm-json';
+import { buildExampleEventSpec } from './helpers';
 
 const EVENT_NAME = 'view_promotion';
 
@@ -36,24 +37,8 @@ const recording: Recording = {
   ]
 };
 
-const tag = exampleGtmJson.containerVersion.tag.find(
-  (t) => t.parameter.find((p) => p.key === 'eventName')?.value === EVENT_NAME
-);
-if (!tag) {
-  throw new Error(
-    `Tag with eventName "${EVENT_NAME}" not found in exampleGtmJson`
-  );
-}
-const normalizedTag: TagConfig = tag;
-
-const triggerNormalized = exampleGtmJson.containerVersion.trigger.find(
-  (t) => t.triggerId && (tag.firingTriggerId || []).includes(t.triggerId)
-) as unknown as TriggerConfig | undefined;
-
-const spec: Spec = {
-  tag: normalizedTag,
-  trigger: triggerNormalized ? [triggerNormalized] : []
-};
+const spec = buildExampleEventSpec(exampleGtmJson, EVENT_NAME);
+const normalizedTag = spec.tag;
 
 export const viewPromotionExample = {
   eventName: EVENT_NAME,

--- a/apps/nest-backend/src/features/gtm-parser/gtm-parser.service.ts
+++ b/apps/nest-backend/src/features/gtm-parser/gtm-parser.service.ts
@@ -6,7 +6,13 @@ import {
   ProjectEventsBuilderService,
   BuildEventInput
 } from '../project-agent/project-events-builder/project-events-builder.service';
-import { GTMConfiguration, TagConfig, TriggerConfig, Parameter } from '@utils';
+import {
+  GTMConfiguration,
+  TagConfig,
+  TriggerConfig,
+  getParameterValue,
+  isGTMConfiguration
+} from '@utils';
 
 @Injectable()
 export class GtmParserService {
@@ -21,40 +27,46 @@ export class GtmParserService {
   // For now, we simply save and build from the provided GTM JSON.
   async uploadGtmJson(projectSlug: string, json: unknown) {
     try {
-      const hasContainerVersion = (obj: unknown): obj is GTMConfiguration =>
-        typeof obj === 'object' && obj !== null && 'containerVersion' in obj;
-
       // Normalize input to a proper object; callers may send a stringified JSON
-      let gtmObject: GTMConfiguration;
+      let parsedPayload: unknown = json;
       try {
-        gtmObject =
-          typeof json === 'string'
-            ? (JSON.parse(json) as GTMConfiguration)
-            : (json as GTMConfiguration);
+        parsedPayload = typeof json === 'string' ? JSON.parse(json) : json;
       } catch (e) {
         this.logger.warn(
           'Received invalid JSON payload; will attempt to continue using saved file. Error: ' +
             (e instanceof Error ? e.message : String(e))
         );
-        // Fallback to an empty object; we will read from file after save
-        gtmObject = {} as GTMConfiguration;
+        parsedPayload = null;
       }
+      const gtmObject = isGTMConfiguration(parsedPayload)
+        ? parsedPayload
+        : null;
 
       const folderPath =
         await this.folderPathService.getProjectConfigFolderPath(projectSlug);
       this.logger.log(`GTM JSON uploaded for project: ${projectSlug}`);
       const filePath = join(folderPath, 'gtm-container.json');
-      // Always write a well-formed object to disk when available
-      this.fileService.writeJsonFile(filePath, gtmObject);
+      if (gtmObject) {
+        this.fileService.writeJsonFile(filePath, gtmObject);
+      } else {
+        this.logger.warn(
+          'Uploaded payload is not a valid GTM configuration; preserving the existing saved file.'
+        );
+      }
 
       // Try to parse and build events immediately
       try {
-        // Prefer the normalized object; if it's missing required fields, re-read from disk
-        const fromDisk =
-          this.fileService.readJsonFile<GTMConfiguration>(filePath);
-        const gtm: GTMConfiguration = hasContainerVersion(gtmObject)
-          ? gtmObject
-          : fromDisk;
+        // Prefer the normalized object; otherwise fall back to the existing saved file.
+        const fromDisk = this.fileService.readJsonFile<unknown>(filePath);
+        const gtm =
+          gtmObject ?? (isGTMConfiguration(fromDisk) ? fromDisk : null);
+
+        if (!gtm) {
+          this.logger.warn(
+            'Uploaded JSON saved but no valid GTM configuration was available to build events.'
+          );
+          return { saved: true };
+        }
 
         const tags = gtm.containerVersion?.tag ?? [];
         const triggers = gtm.containerVersion?.trigger ?? [];
@@ -96,9 +108,7 @@ export class GtmParserService {
     tag: TagConfig,
     allTriggers: TriggerConfig[]
   ): BuildEventInput | null {
-    const eventNameParam = tag.parameter?.find(
-      (p: Parameter) => p?.key === 'eventName' && typeof p.value === 'string'
-    )?.value as string | undefined;
+    const eventNameParam = getParameterValue(tag.parameter, 'eventName');
 
     if (!eventNameParam) return null;
 

--- a/apps/nest-backend/src/features/project-agent/project-data-layer-spec-builder/project-data-layer-spec.builder.service.ts
+++ b/apps/nest-backend/src/features/project-agent/project-data-layer-spec-builder/project-data-layer-spec.builder.service.ts
@@ -1,14 +1,18 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Spec, StrictDataLayerEvent } from '@utils';
+import {
+  Spec,
+  StrictDataLayerEvent,
+  getParameterListItems,
+  getParameterMapValue,
+  getParameterValue
+} from '@utils';
 
 @Injectable()
 export class ProjectDataLayerSpecBuilderService {
   private readonly logger = new Logger(ProjectDataLayerSpecBuilderService.name);
   buildDataLayerSpec(spec: Spec): StrictDataLayerEvent {
     // 1) Resolve event name from tag parameters, fallback to tag name suffix
-    const eventNameParam = spec.tag.parameter.find(
-      (p) => p.key === 'eventName' && typeof p.value === 'string'
-    )?.value as string | undefined;
+    const eventNameParam = getParameterValue(spec.tag.parameter, 'eventName');
 
     if (!eventNameParam) {
       this.logger.warn(`No eventName found for spec=${JSON.stringify(spec)}`);
@@ -23,25 +27,19 @@ export class ProjectDataLayerSpecBuilderService {
     //    TEMPLATE entries: { key: 'parameter', value: '<field>' }
     //                      { key: 'parameterValue', value: '<template or literal>' }
     const eventSettings = spec.tag.parameter.find(
-      (p) => p.key === 'eventSettingsTable' && Array.isArray(p.list)
+      (p) => p.key === 'eventSettingsTable' && p.type === 'LIST'
     );
 
-    if (!eventSettings?.list) {
+    if (!eventSettings) {
       return result; // No ecommerce mapping
     }
 
     // Use a flexible record to allow template strings for values, including items
     const ecommerce: Record<string, unknown> = {};
 
-    for (const entry of eventSettings.list) {
-      if (!entry || entry.type !== 'MAP' || !('map' in entry) || !entry.map)
-        continue;
-      // Find inner TEMPLATE params
-      const paramName = entry.map.find((m) => m.key === 'parameter')?.value as
-        | string
-        | undefined;
-      const paramValueTpl = entry.map.find((m) => m.key === 'parameterValue')
-        ?.value as string | undefined;
+    for (const entry of getParameterListItems(eventSettings)) {
+      const paramName = getParameterMapValue(entry, 'parameter');
+      const paramValueTpl = getParameterMapValue(entry, 'parameterValue');
       // Only map when both parameter and parameterValue exist
       if (!paramName || typeof paramName !== 'string') continue;
       if (typeof paramValueTpl !== 'string' || paramValueTpl.length === 0)

--- a/apps/ng-frontend/src/app/modules/project/components/ga4-upload/ga4-upload-facade.service.ts
+++ b/apps/ng-frontend/src/app/modules/project/components/ga4-upload/ga4-upload-facade.service.ts
@@ -4,8 +4,8 @@ import { ReportService } from '../../../../shared/services/api/report/report.ser
 import {
   ReportDetailsDto,
   StrictDataLayerEvent,
-  Spec,
-  Recording
+  Recording,
+  createPlaceholderSpec
 } from '@utils';
 import {
   catchError,
@@ -130,16 +130,7 @@ export class Ga4UploadFacadeService {
       });
 
       // minimal placeholder Spec so backend can persist rawGtmTag
-      const spec: Spec = {
-        tag: {
-          name: `GA4 event - ${eventName}`,
-          type: 'gaawe',
-          accountId: '',
-          containerId: '',
-          parameter: []
-        },
-        trigger: []
-      };
+      const spec = createPlaceholderSpec(`GA4 event - ${eventName}`);
 
       const recording: Recording = { title: eventName, steps: [] };
 

--- a/apps/ng-frontend/src/app/modules/project/components/tag-manage-tab/tag-manage-tab.component.ts
+++ b/apps/ng-frontend/src/app/modules/project/components/tag-manage-tab/tag-manage-tab.component.ts
@@ -4,7 +4,14 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatTableModule } from '@angular/material/table';
 import { MatDividerModule } from '@angular/material/divider';
-import { Parameter, TagSpec, TriggerConfig } from '@utils';
+import {
+  Parameter,
+  TagSpec,
+  TriggerConfig,
+  getParameterListItems,
+  getParameterMapValue,
+  getParameterValue
+} from '@utils';
 import { MatButtonModule } from '@angular/material/button';
 
 export interface EventParameter {
@@ -41,30 +48,33 @@ export class TagManageTabComponent {
 
   // Measurement ID: show standard template used by GoogleTag generator
   measurementId$ = computed(() => {
-    const parameter = this.tagConfig$()?.parameter ?? [];
-    const measurementIdOverride = parameter.find(
-      (p) => p.key === 'measurementIdOverride'
+    return (
+      getParameterValue(
+        this.tagConfig$()?.parameter,
+        'measurementIdOverride'
+      ) ?? ''
     );
-    return measurementIdOverride?.value ?? '';
   });
 
   // Google Tag reference name from the Event tag parameters (TAG_REFERENCE measurementId)
   googleTagName$ = computed(() => {
-    const params = this.tagConfig$()?.parameter ?? [];
-    const ref = params.find(
-      (p) => p.key === 'measurementId' && p.type === 'TAG_REFERENCE'
+    return (
+      getParameterValue(
+        this.tagConfig$()?.parameter,
+        'measurementId',
+        'TAG_REFERENCE'
+      ) ?? 'GoogleTag'
     );
-    return ref?.value ?? 'GoogleTag';
   });
 
   // Event name from the Event tag parameters or tagSpec fallback
   eventName$ = computed(() => {
-    const params = this.tagConfig$()?.parameter ?? [];
-    const nameParam = params.find(
-      (p) => p.key === 'eventName' && p.type === 'TEMPLATE'
-    );
     return (
-      (nameParam?.value as string | undefined) ||
+      getParameterValue(
+        this.tagConfig$()?.parameter,
+        'eventName',
+        'TEMPLATE'
+      ) ||
       this.tagSpec()?.eventName ||
       this.tagSpec()?.event ||
       ''
@@ -99,19 +109,10 @@ export class TagManageTabComponent {
     const listParam = params.find(
       (p) => p.key === 'eventSettingsTable' && p.type === 'LIST'
     );
-    const list = (listParam?.list ?? []) as Array<
-      | { type: string; map: Parameter[] }
-      | { type: string; value?: string; map?: Parameter[] }
-    >;
-    // Each item is a MAP with entries for 'parameter' and 'parameterValue'
-    return list
+    return getParameterListItems(listParam)
       .map((item) => {
-        const map: Parameter[] = (item?.map ?? []) as unknown as Parameter[];
-        const paramName = map.find((m) => m.key === 'parameter')?.value as
-          | string
-          | undefined;
-        const paramValue = map.find((m) => m.key === 'parameterValue')
-          ?.value as string | undefined;
+        const paramName = getParameterMapValue(item, 'parameter');
+        const paramValue = getParameterMapValue(item, 'parameterValue');
         if (!paramName || !paramValue) return undefined;
         return { parameter: paramName, value: paramValue } as EventParameter;
       })

--- a/apps/ng-frontend/src/app/modules/tag-build/views/tag-build-view.component.ts
+++ b/apps/ng-frontend/src/app/modules/tag-build/views/tag-build-view.component.ts
@@ -2,7 +2,7 @@ import { AsyncPipe, NgComponentOutlet } from '@angular/common';
 import { Component, computed, OnDestroy, OnInit, signal } from '@angular/core';
 import { Subject, takeUntil, tap } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
-import { Spec } from '@utils';
+import { StrictDataLayerEvent } from '@utils';
 import { SpecService } from '../../../shared/services/api/spec/spec.service';
 
 @Component({
@@ -28,7 +28,7 @@ import { SpecService } from '../../../shared/services/api/spec/spec.service';
 })
 export class TagBuildViewComponent implements OnInit, OnDestroy {
   tagBuildPageComponent = this.loadTagBuildPageComponent();
-  projectSpecSignal = signal([] as Spec[]);
+  projectSpecSignal = signal([] as StrictDataLayerEvent[]);
   projectSpecSignal$ = computed(() => this.projectSpecSignal());
   destroy$ = new Subject<void>();
 

--- a/apps/ng-frontend/src/app/shared/services/api/gtm-json-parser/gtm-json-parser.service.ts
+++ b/apps/ng-frontend/src/app/shared/services/api/gtm-json-parser/gtm-json-parser.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { GTMConfiguration } from '@utils';
+import { GTMConfiguration, isGTMConfiguration } from '@utils';
 import { environment } from '../../../../../environments/environment';
 
 @Injectable({
@@ -10,7 +10,10 @@ export class GtmJsonParserService {
   constructor(private readonly httpClient: HttpClient) {}
 
   parseGtmJson(json: string) {
-    const result = JSON.parse(json) as GTMConfiguration;
+    const result = JSON.parse(json) as unknown;
+    if (!isGTMConfiguration(result)) {
+      throw new Error('Invalid GTM configuration JSON.');
+    }
     return result;
   }
 

--- a/apps/ng-tag-build/tsconfig.json
+++ b/apps/ng-tag-build/tsconfig.json
@@ -11,7 +11,7 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
-    "moduleResolution": "node10",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
     "useDefineForClassFields": false,

--- a/libs/data-access/src/lib/services/gtm-json-converter/extract/spec-extract.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/extract/spec-extract.service.spec.ts
@@ -1,0 +1,96 @@
+import { TestBed } from '@angular/core/testing';
+import { SpecExtractService } from './spec-extract.service';
+import { vi } from 'vitest';
+
+describe('SpecExtractService', () => {
+  let service: SpecExtractService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [SpecExtractService]
+    });
+    service = TestBed.inject(SpecExtractService);
+  });
+
+  it('normalizes a single event object into an array', () => {
+    expect(service.preprocessInput('{ "event": "page_view" }')).toEqual([
+      { event: 'page_view' }
+    ]);
+  });
+
+  it('passes through a valid multi-event array', () => {
+    expect(
+      service.preprocessInput(
+        '[{ "event": "page_view" }, { "event": "purchase", "value": "799" }]'
+      )
+    ).toEqual([{ event: 'page_view' }, { event: 'purchase', value: '799' }]);
+  });
+
+  it('repairs lightly malformed JSON input before parsing', () => {
+    expect(service.preprocessInput('[{ event: page_view }]')).toEqual([
+      { event: 'page_view' }
+    ]);
+  });
+
+  it('repairs comments and trailing commas before parsing', () => {
+    expect(
+      service.preprocessInput(`[
+        /* comment */
+        {
+          event: page_view, // tracking
+        },
+      ]`)
+    ).toEqual([{ event: 'page_view' }]);
+  });
+
+  it('throws when semantically invalid JSON cannot be normalized into event objects', () => {
+    expect(() =>
+      service.preprocessInput('[{ "name": "missing event" }]')
+    ).toThrow('Error parsing spec JSON. Please check the format.');
+  });
+
+  it('does not attempt JSON repair when valid JSON fails schema normalization', () => {
+    const repairSpy = vi.spyOn(service, 'fixJsonString');
+
+    expect(() =>
+      service.preprocessInput('[{ "name": "missing event" }]')
+    ).toThrow('Error parsing spec JSON. Please check the format.');
+    expect(repairSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws when repaired JSON still fails event normalization', () => {
+    const repairSpy = vi.spyOn(service, 'fixJsonString');
+
+    expect(() =>
+      service.preprocessInput("[{ 'name': 'missing event' }]")
+    ).toThrow('Error parsing spec JSON. Please check the format.');
+    expect(repairSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when the input cannot be repaired into valid JSON', () => {
+    expect(() => service.preprocessInput('}}garbage{{')).toThrow(
+      'Error parsing spec JSON. Please check the format.'
+    );
+  });
+
+  it('leaves already valid JSON unchanged when applying repair helpers', () => {
+    const input = '[{ "event": "page_view" }]';
+
+    expect(service.fixJsonString(input)).toBe(input);
+  });
+
+  it('preserves apostrophes inside already double-quoted strings', () => {
+    const input = '{ "message": "It\'s working" }';
+
+    expect(service.fixJsonString(input)).toBe(input);
+  });
+
+  it('documents that standalone line comments are not repaired', () => {
+    expect(() =>
+      service.preprocessInput(`[
+          // unsupported standalone comment
+          { "event": "page_view" }
+        ]`)
+    ).toThrow('Error parsing spec JSON. Please check the format.');
+  });
+});

--- a/libs/data-access/src/lib/services/gtm-json-converter/extract/spec-extract.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/extract/spec-extract.service.ts
@@ -1,35 +1,37 @@
-import { Spec } from '@utils';
+import {
+  StrictDataLayerEvent,
+  isStrictDataLayerEvent,
+  isStrictDataLayerEventArray
+} from '@utils';
 import { Injectable } from '@angular/core';
 
 @Injectable({
   providedIn: 'root'
 })
 export class SpecExtractService {
-  preprocessInput(inputString: string) {
-    try {
-      // Attempt to parse the input JSON string
-      return JSON.parse(inputString) as Spec[];
-    } catch (error) {
-      // If parsing fails, attempt to fix common issues and try again
-      console.warn(
-        'JSON parsing failed, attempting to fix common issues:',
-        error
-      );
-      let fixedString = '';
-      fixedString = this.fixJsonString(inputString);
+  preprocessInput(inputString: string): StrictDataLayerEvent[] {
+    const parsedInput = this.parseInput(inputString);
 
-      // Attempt to parse the fixed string
-      try {
-        return JSON.parse(fixedString) as Spec[];
-      } catch (error) {
-        console.error(error);
-        return [
-          {
-            tag: { name: 'Error parsing spec JSON. Please check the format.' }
-          }
-        ] as Spec[];
-      }
+    try {
+      return this.normalizeSpecs(parsedInput);
+    } catch (error) {
+      console.error(error);
+      throw new Error('Error parsing spec JSON. Please check the format.');
     }
+  }
+
+  private normalizeSpecs(input: unknown): StrictDataLayerEvent[] {
+    if (isStrictDataLayerEventArray(input)) {
+      return input;
+    }
+
+    if (isStrictDataLayerEvent(input)) {
+      return [input];
+    }
+
+    throw new Error(
+      'Spec JSON must be an event object or an array of event objects.'
+    );
   }
 
   fixJsonString(inputString: string) {
@@ -54,12 +56,16 @@ export class SpecExtractService {
 
       fixedString = lines.join('\n');
 
-      // Replace single quotes with double quotes
-      fixedString = fixedString.replaceAll("'", '"');
-
-      // Handle mismatched quotes
-      fixedString = fixedString.replaceAll(/"([^"]*)'(?![^"]*")/g, '"$1"');
-      fixedString = fixedString.replaceAll(/(?<![^"]*')'([^"]*)"/g, '"$1"');
+      // Convert single-quoted JSON keys and string values without
+      // rewriting apostrophes inside already double-quoted content.
+      fixedString = fixedString.replaceAll(
+        /([{,]\s*)'([^']+)'(\s*:)/g,
+        '$1"$2"$3'
+      );
+      fixedString = fixedString.replaceAll(
+        /(:\s*)'([^']*)'(?=\s*[,}\]])/g,
+        '$1"$2"'
+      );
 
       // Wrap unquoted property names with double quotes
       fixedString = fixedString.replaceAll(
@@ -82,6 +88,25 @@ export class SpecExtractService {
       return fixedString;
     } catch (error) {
       throw new Error('Failed to fix JSON parsing issues: ' + error);
+    }
+  }
+
+  private parseInput(inputString: string): unknown {
+    try {
+      return JSON.parse(inputString) as unknown;
+    } catch (error) {
+      console.warn(
+        'JSON parsing failed, attempting to fix common issues:',
+        error
+      );
+      const fixedString = this.fixJsonString(inputString);
+
+      try {
+        return JSON.parse(fixedString) as unknown;
+      } catch (repairError) {
+        console.error(repairError);
+        throw new Error('Error parsing spec JSON. Please check the format.');
+      }
     }
   }
 }

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/utils/parameter-utils.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/utils/parameter-utils.service.ts
@@ -1,5 +1,10 @@
 import { Injectable } from '@angular/core';
-import { Parameter, ParameterMap, Trigger } from '@utils';
+import {
+  Parameter,
+  ParameterMap,
+  Trigger,
+  isParameterWithKeyValue
+} from '@utils';
 
 /**
  * Service for constructing GTM JSON parameters and utilities for data layer variables.
@@ -18,14 +23,8 @@ export class ParameterUtils {
    * @returns A {@link Parameter} of type LIST containing mapped parameters.
    */
   createListParameter(key: string, parameters: Parameter[]): Parameter {
-    // Guard against optional key/value in Parameter type
     const list = parameters
-      .filter(
-        (
-          param
-        ): param is Parameter & Required<Pick<Parameter, 'key' | 'value'>> =>
-          typeof param.key === 'string' && typeof param.value === 'string'
-      )
+      .filter(isParameterWithKeyValue)
       .map((param) =>
         this.createMapParameter(param.key, `{{DLV - ${param.value}}}`)
       );

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/utils/parameter-utils.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/utils/parameter-utils.spec.ts
@@ -1,6 +1,12 @@
 import { TestBed } from '@angular/core/testing';
 import { ParameterUtils } from './parameter-utils.service';
-import { Parameter, ParameterMap, Trigger } from '@utils';
+import {
+  Parameter,
+  ParameterMap,
+  Trigger,
+  getParameterListItems,
+  getParameterMapValue
+} from '@utils';
 
 describe('ParameterUtils', () => {
   let service: ParameterUtils;
@@ -37,15 +43,38 @@ describe('ParameterUtils', () => {
     ];
 
     const result = service.createListParameter(key, parameters);
+    const list = getParameterListItems(result);
 
     expect(result.type).toBe('LIST');
     expect(result.key).toBe(key);
-    expect(result.list?.length).toBe(3);
-    expect(result.list?.[0].map?.[1]?.value).toBe('{{DLV - ecommerce.value}}');
-    expect(result.list?.[1].map?.[1]?.value).toBe(
+    expect(list).toHaveLength(3);
+    expect(getParameterMapValue(list[0], 'parameterValue')).toBe(
+      '{{DLV - ecommerce.value}}'
+    );
+    expect(getParameterMapValue(list[1], 'parameterValue')).toBe(
       '{{DLV - ecommerce.currency}}'
     );
-    expect(result.list?.[2].map?.[1]?.value).toBe('{{DLV - ecommerce.items}}');
+    expect(getParameterMapValue(list[2], 'parameterValue')).toBe(
+      '{{DLV - ecommerce.items}}'
+    );
+  });
+
+  it('should ignore parameters that do not have both a key and a value', () => {
+    const result = service.createListParameter('testKey', [
+      { type: 'v', key: 'value', value: 'ecommerce.value' },
+      { type: 'v', key: 'missingValue' },
+      { type: 'v', value: 'missingKey' }
+    ]);
+
+    expect(getParameterListItems(result)).toHaveLength(1);
+  });
+
+  it('should create an empty list parameter when no eligible entries are provided', () => {
+    const result = service.createListParameter('testKey', []);
+
+    expect(result.type).toBe('LIST');
+    expect(result.key).toBe('testKey');
+    expect(getParameterListItems(result)).toEqual([]);
   });
 
   it('should create a built-in list parameter correctly', () => {
@@ -69,8 +98,10 @@ describe('ParameterUtils', () => {
     const result = service.createMapParameter(name, value);
 
     expect(result.type).toBe('MAP');
+    expect(result.map[0].type).toBe('TEMPLATE');
     expect(result.map[0].key).toBe('parameter');
     expect(result.map[0].value).toBe(name);
+    expect(result.map[1].type).toBe('TEMPLATE');
     expect(result.map[1].key).toBe('parameterValue');
     expect(result.map[1].value).toBe(value);
   });
@@ -145,5 +176,33 @@ describe('ParameterUtils', () => {
     const result = service.findTriggerIdByEventName(eventName, triggers);
 
     expect(result).toEqual([]);
+  });
+
+  it('should return all matching trigger IDs for the same event name', () => {
+    const eventName = 'select_promotion';
+    const triggers: Trigger[] = [
+      {
+        name: 'select_promotion',
+        triggerId: '1'
+      },
+      {
+        name: 'page_view',
+        triggerId: '2'
+      },
+      {
+        name: 'select_promotion',
+        triggerId: '3'
+      }
+    ];
+
+    const result = service.findTriggerIdByEventName(eventName, triggers);
+
+    expect(result).toEqual(['1', '3']);
+  });
+
+  it('should return an empty array when no triggers are provided', () => {
+    expect(service.findTriggerIdByEventName('select_promotion', [])).toEqual(
+      []
+    );
   });
 });

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/utils/tag-build-contract.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/utils/tag-build-contract.spec.ts
@@ -1,0 +1,399 @@
+import {
+  createPlaceholderTagConfig,
+  createPlaceholderSpec,
+  getParameterListItems,
+  getParameterMapValue,
+  getParameterValue,
+  isGTMConfiguration,
+  isParameter,
+  isParameterWithKeyValue,
+  isParameterListItem,
+  isParameterMap,
+  isSpec,
+  isSpecArray,
+  isStrictDataLayerEvent,
+  isStrictDataLayerEventArray,
+  isTagConfig,
+  isTrigger,
+  isTriggerConfig,
+  isVariableConfig,
+  TagTypeEnum,
+  type TriggerConfig
+} from '@utils';
+
+describe('tag-build contract helpers', () => {
+  const validTagParameter = {
+    type: 'TEMPLATE',
+    key: 'eventName',
+    value: 'page_view'
+  } as const;
+
+  const validTrigger: TriggerConfig = {
+    name: 'page_view',
+    type: 'CUSTOM_EVENT',
+    accountId: 'account-1',
+    containerId: 'container-1',
+    triggerId: 'trigger-1',
+    firingTriggerId: ['trigger-2'],
+    parameter: [validTagParameter]
+  };
+
+  const validVariable = {
+    name: 'DLV - page_view',
+    type: 'v',
+    accountId: 'account-1',
+    containerId: 'container-1',
+    parameter: [validTagParameter]
+  } as const;
+
+  it('creates placeholder specs that satisfy the shared raw GTM spec contract', () => {
+    const spec = createPlaceholderSpec('GA4 event - page_view');
+
+    expect(isSpec(spec)).toBe(true);
+    expect(spec.tag.name).toBe('GA4 event - page_view');
+    expect(spec.tag.parameter).toEqual([]);
+    expect(spec.trigger).toEqual([]);
+  });
+
+  it('supports placeholder overrides without breaking the raw GTM contract', () => {
+    const spec = createPlaceholderSpec('GA4 event - page_view', {
+      tag: {
+        type: TagTypeEnum.GOOGLE_TAG,
+        accountId: 'account-1',
+        containerId: 'container-1',
+        parameter: [validTagParameter]
+      },
+      trigger: [validTrigger]
+    });
+
+    expect(spec.tag.type).toBe(TagTypeEnum.GOOGLE_TAG);
+    expect(spec.tag.accountId).toBe('account-1');
+    expect(spec.tag.containerId).toBe('container-1');
+    expect(spec.tag.parameter).toEqual([validTagParameter]);
+    expect(spec.trigger).toEqual([validTrigger]);
+    expect(isSpec(spec)).toBe(true);
+  });
+
+  it('creates placeholder tag configs with the documented defaults', () => {
+    expect(
+      createPlaceholderTagConfig({ name: 'GA4 event - page_view' })
+    ).toEqual({
+      name: 'GA4 event - page_view',
+      type: TagTypeEnum.GAAWE,
+      accountId: '',
+      containerId: '',
+      parameter: []
+    });
+  });
+
+  it('recognizes valid GTM configuration objects and rejects invalid ones', () => {
+    const configuration = {
+      exportFormatVersion: 2,
+      exportTime: '2026-04-22 00:00:00',
+      containerVersion: {
+        variable: [validVariable],
+        builtInVariable: [
+          {
+            name: 'Page URL',
+            type: 'PAGE_URL',
+            accountId: 'account-1',
+            containerId: 'container-1'
+          }
+        ],
+        trigger: [validTrigger],
+        tag: [createPlaceholderSpec('GA4 event - page_view').tag]
+      }
+    };
+
+    expect(isGTMConfiguration(configuration)).toBe(true);
+    expect(isGTMConfiguration({ exportFormatVersion: 2 })).toBe(false);
+    expect(
+      isGTMConfiguration({
+        ...configuration,
+        exportFormatVersion: '2'
+      })
+    ).toBe(false);
+    expect(
+      isGTMConfiguration({
+        ...configuration,
+        exportTime: 123
+      })
+    ).toBe(false);
+    expect(
+      isGTMConfiguration({
+        ...configuration,
+        containerVersion: {
+          ...configuration.containerVersion,
+          tag: [{ ...configuration.containerVersion.tag[0], parameter: 'bad' }]
+        }
+      })
+    ).toBe(false);
+    expect(
+      isGTMConfiguration({
+        ...configuration,
+        containerVersion: {
+          ...configuration.containerVersion,
+          variable: [{ ...validVariable, parameter: 'bad' }]
+        }
+      })
+    ).toBe(false);
+    expect(
+      isGTMConfiguration({
+        ...configuration,
+        containerVersion: {
+          ...configuration.containerVersion,
+          builtInVariable: [
+            {
+              ...configuration.containerVersion.builtInVariable[0],
+              parameter: 'bad'
+            }
+          ]
+        }
+      })
+    ).toBe(false);
+    expect(
+      isGTMConfiguration({
+        ...configuration,
+        containerVersion: {
+          ...configuration.containerVersion,
+          trigger: [{ ...validTrigger, firingTriggerId: 'trigger-2' }]
+        }
+      })
+    ).toBe(false);
+  });
+
+  it('validates parameter helpers at the guard layer directly', () => {
+    expect(isParameter({ type: 'TEMPLATE' })).toBe(true);
+    expect(isParameter({ type: 'TEMPLATE', key: 42 })).toBe(false);
+    expect(isParameter({ type: 'TEMPLATE', value: 42 })).toBe(false);
+    expect(isParameter({ type: 'LIST', list: 'bad' })).toBe(false);
+    expect(isParameter({ type: 'LIST', list: [{ type: 123 }] })).toBe(false);
+    expect(
+      isParameterWithKeyValue({
+        type: 'TEMPLATE',
+        key: 'eventName',
+        value: 'page_view'
+      })
+    ).toBe(true);
+    expect(
+      isParameterWithKeyValue({ type: 'TEMPLATE', key: 'eventName' })
+    ).toBe(false);
+    expect(
+      isParameterWithKeyValue({ type: 'TEMPLATE', value: 'page_view' })
+    ).toBe(false);
+    expect(isParameterWithKeyValue({ type: 'TEMPLATE' })).toBe(false);
+    expect(isParameterMap({ type: 'MAP', map: [validTagParameter] })).toBe(
+      true
+    );
+    expect(isParameterMap({ type: 'MAP', map: [{ type: 123 }] })).toBe(false);
+    expect(isParameterMap({ type: 'TEMPLATE', map: [] })).toBe(false);
+    expect(isParameterListItem(validTagParameter)).toBe(true);
+    expect(isParameterListItem({ type: 'MAP', map: [validTagParameter] })).toBe(
+      true
+    );
+    expect(isParameterListItem({ type: 'TEMPLATE', map: 'bad' })).toBe(false);
+    expect(isParameterListItem({ type: 'TEMPLATE', value: 99 })).toBe(false);
+  });
+
+  it('validates basic trigger guards directly', () => {
+    expect(isTrigger({ name: 'page_view', triggerId: '1' })).toBe(true);
+    expect(isTrigger({ name: 'page_view', triggerId: 1 })).toBe(false);
+    expect(isTrigger({ name: 'page_view' })).toBe(false);
+    expect(isTrigger(null)).toBe(false);
+  });
+
+  it('recognizes strict data-layer event arrays', () => {
+    expect(isStrictDataLayerEvent({ event: 'page_view' })).toBe(true);
+    expect(isStrictDataLayerEvent({ event: 123 })).toBe(false);
+    expect(
+      isStrictDataLayerEventArray([
+        { event: 'page_view' },
+        { event: 'purchase', value: '799' }
+      ])
+    ).toBe(true);
+    expect(isStrictDataLayerEventArray([{ name: 'missing event' }])).toBe(
+      false
+    );
+    expect(isStrictDataLayerEventArray([{ event: 123 }])).toBe(false);
+  });
+
+  it('documents that an empty event array is still structurally valid', () => {
+    expect(isStrictDataLayerEventArray([])).toBe(true);
+  });
+
+  it('reads parameter values through the shared helper layer', () => {
+    const parameters = [
+      {
+        type: 'TEMPLATE',
+        key: 'eventName',
+        value: 'page_view'
+      },
+      {
+        type: 'INTEGER',
+        key: 'value',
+        value: '799'
+      }
+    ];
+
+    expect(getParameterValue(parameters, 'eventName')).toBe('page_view');
+    expect(getParameterValue(parameters, 'value', 'INTEGER')).toBe('799');
+    expect(getParameterValue(parameters, 'value', 'TEMPLATE')).toBeUndefined();
+    expect(getParameterValue(parameters, 'missing')).toBeUndefined();
+  });
+
+  it('returns safe fallback values for nullable list and map lookups', () => {
+    const listParameter = {
+      type: 'LIST',
+      key: 'eventSettingsTable',
+      list: [
+        {
+          type: 'MAP',
+          map: [
+            {
+              type: 'TEMPLATE',
+              key: 'parameter',
+              value: 'currency'
+            },
+            {
+              type: 'TEMPLATE',
+              key: 'parameterValue',
+              value: '{{DLV - ecommerce.currency}}'
+            }
+          ]
+        }
+      ]
+    } as const;
+
+    const list = getParameterListItems(listParameter);
+
+    expect(getParameterListItems(null)).toEqual([]);
+    expect(getParameterListItems(undefined)).toEqual([]);
+    expect(list).toHaveLength(1);
+    expect(getParameterMapValue(list[0], 'parameterValue')).toBe(
+      '{{DLV - ecommerce.currency}}'
+    );
+    expect(
+      getParameterMapValue(
+        {
+          type: 'TEMPLATE',
+          key: 'parameter',
+          value: 'currency'
+        },
+        'parameterValue'
+      )
+    ).toBeUndefined();
+    expect(getParameterMapValue(null, 'parameterValue')).toBeUndefined();
+  });
+
+  it('rejects malformed tag configs', () => {
+    expect(
+      isTagConfig({
+        name: 'GA4 event - page_view',
+        type: TagTypeEnum.GAAWE,
+        accountId: 'account-1',
+        containerId: 'container-1',
+        parameter: [validTagParameter],
+        firingTriggerId: ['trigger-1'],
+        tagFiringOption: 'ONCE_PER_EVENT'
+      })
+    ).toBe(true);
+    expect(
+      isTagConfig({
+        name: 'GA4 event - page_view',
+        type: TagTypeEnum.GAAWE,
+        accountId: 'account-1',
+        containerId: 'container-1',
+        parameter: 'bad'
+      })
+    ).toBe(false);
+    expect(
+      isTagConfig({
+        name: 'GA4 event - page_view',
+        type: TagTypeEnum.GAAWE,
+        accountId: 'account-1',
+        containerId: 'container-1',
+        parameter: [validTagParameter],
+        firingTriggerId: 'trigger-1'
+      })
+    ).toBe(false);
+    expect(
+      isTagConfig({
+        name: 'GA4 event - page_view',
+        type: TagTypeEnum.GAAWE,
+        accountId: 'account-1',
+        containerId: 'container-1',
+        parameter: [validTagParameter],
+        tagFiringOption: 1
+      })
+    ).toBe(false);
+  });
+
+  it('accepts and rejects trigger configs through direct guard tests', () => {
+    expect(isTriggerConfig(validTrigger)).toBe(true);
+    expect(
+      isTriggerConfig({
+        ...validTrigger,
+        type: undefined
+      })
+    ).toBe(false);
+    expect(
+      isTriggerConfig({
+        ...validTrigger,
+        firingTriggerId: 'trigger-2'
+      })
+    ).toBe(false);
+    expect(
+      isTriggerConfig({
+        ...validTrigger,
+        triggerId: 123
+      })
+    ).toBe(false);
+    expect(
+      isTriggerConfig({
+        ...validTrigger,
+        parameter: [{ type: 123 }]
+      })
+    ).toBe(false);
+  });
+
+  it('accepts and rejects variable configs through direct guard tests', () => {
+    expect(isVariableConfig(validVariable)).toBe(true);
+    expect(
+      isVariableConfig({
+        name: 'Page URL',
+        type: 'PAGE_URL',
+        accountId: 'account-1',
+        containerId: 'container-1'
+      })
+    ).toBe(true);
+    expect(
+      isVariableConfig({
+        ...validVariable,
+        containerId: undefined
+      })
+    ).toBe(false);
+    expect(
+      isVariableConfig({
+        ...validVariable,
+        parameter: [{ type: 123 }]
+      })
+    ).toBe(false);
+  });
+
+  it('recognizes spec arrays through the shared contract helper', () => {
+    const spec = createPlaceholderSpec('GA4 event - page_view', {
+      trigger: [validTrigger]
+    });
+
+    expect(isSpec(spec)).toBe(true);
+    expect(isSpec({ tag: spec.tag })).toBe(false);
+    expect(isSpec({ trigger: spec.trigger })).toBe(false);
+    expect(isSpecArray([spec])).toBe(true);
+    expect(isSpecArray([])).toBe(true);
+    expect(isSpecArray([{ tag: spec.tag }])).toBe(false);
+  });
+
+  it('rejects missing required tag config fields at baseline', () => {
+    expect(isTagConfig({})).toBe(false);
+  });
+});

--- a/libs/data-access/src/lib/services/gtm-json-converter/utils/data-layer-utils.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/utils/data-layer-utils.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { DataLayer, Spec } from '@utils';
+import { DataLayer, StrictDataLayerEvent } from '@utils';
 import { UtilsService } from './utils.service';
 
 @Injectable({
@@ -7,18 +7,15 @@ import { UtilsService } from './utils.service';
 })
 export class DataLayerUtils {
   constructor(private readonly utilsService: UtilsService) {}
-  getDataLayers(specs: Spec[]) {
+  getDataLayers(specs: StrictDataLayerEvent[]) {
     const dataLayers: DataLayer[] = [];
-    for (const spec of specs) {
-      const { event, ...rest } = spec as Record<string, unknown>;
-      const paths = this.utilsService.getAllObjectPaths(
-        rest as unknown as Record<string, unknown>
-      );
+    for (const { event, ...rest } of specs) {
+      const paths = this.utilsService.getAllObjectPaths(rest);
       const uniquedPaths = Array.from(new Set(paths));
       const filtered = uniquedPaths.filter(
         (dL) => !dL.includes('items.0') && dL !== 'ecommerce'
       );
-      dataLayers.push({ event: event as string, paths: filtered });
+      dataLayers.push({ event, paths: filtered });
     }
     return dataLayers;
   }

--- a/libs/ui/src/lib/components/functional-card/functional-card.facade.service.ts
+++ b/libs/ui/src/lib/components/functional-card/functional-card.facade.service.ts
@@ -13,7 +13,11 @@ import { containerName, gtmId, tagManagerUrl } from './test-data';
 import { ErrorDialogComponent } from '../error-dialog/error-dialog.component';
 import { MatDialog } from '@angular/material/dialog';
 import { ConversionSuccessDialogComponent } from '../conversion-success-dialog/conversion-success-dialog.component';
-import { GTMContainerConfig, GTMConfiguration, Spec } from '@utils';
+import {
+  GTMContainerConfig,
+  GTMConfiguration,
+  StrictDataLayerEvent
+} from '@utils';
 import { AdvancedExpansionPanelComponent } from '../advanced-expansion-panel/advanced-expansion-panel.component';
 
 @Injectable({ providedIn: 'root' })
@@ -134,7 +138,7 @@ export class FunctionalCardFacade {
         this.setupConstructorService.isSendingEcommerceData$();
       const esvConent = this.esvEditorService.content$();
       let esvContent = null;
-      let json: Spec[] = [];
+      let json: StrictDataLayerEvent[] = [];
 
       try {
         if (esvConent !== '') {
@@ -209,14 +213,14 @@ export class FunctionalCardFacade {
   }
 
   private performConversion(
-    json: Spec[],
+    json: StrictDataLayerEvent[],
     googleTagName: string,
     measurementId: string,
     isSendingEcommerceData: 'true' | 'false',
     esvContent: { name: string; parameters: { [x: string]: string }[] }[]
   ) {
     // set input content for downstream presenters
-    this.editorFacadeService.inputJsonContent = json as unknown as string;
+    this.editorFacadeService.inputJsonContent = json;
 
     const { accountId, containerId } =
       this.utilsService.extractAccountAndContainerId(tagManagerUrl);
@@ -240,7 +244,7 @@ export class FunctionalCardFacade {
   }
 
   private postConversion(result: GTMConfiguration) {
-    this.editorFacadeService.outputJsonContent = result as unknown as string;
+    this.editorFacadeService.outputJsonContent = result;
     this.openSuccessConversionDialog(result);
 
     this.dataLayer.push({

--- a/libs/ui/src/lib/views/tag-build-page/tag-build-page.component.ts
+++ b/libs/ui/src/lib/views/tag-build-page/tag-build-page.component.ts
@@ -5,7 +5,7 @@ import { ErrorDialogComponent } from '../../components/error-dialog/error-dialog
 import { UploadActionComponent } from '../../components/upload-action/upload-action.component';
 import { FileUploadDialogComponent } from '../../components/file-upload-dialog/file-upload-dialog.component';
 import { MatDialog } from '@angular/material/dialog';
-import { EditorTypeEnum, Spec } from '@utils';
+import { EditorTypeEnum, StrictDataLayerEvent } from '@utils';
 import { JsonPipe } from '@angular/common';
 import { MatTabsModule } from '@angular/material/tabs';
 import { TagBuildModeService, TagBuildMode } from '@data-access';
@@ -24,7 +24,7 @@ import { TagBuildModeService, TagBuildMode } from '@data-access';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TagBuildPageComponent {
-  specs = input.required<Spec[]>();
+  specs = input.required<StrictDataLayerEvent[]>();
   inputExtension = EditorTypeEnum.INPUT_JSON;
   outputExtension = EditorTypeEnum.OUTPUT_JSON;
 

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -14,3 +14,4 @@ export * from './lib/dtos/report-details.dto';
 
 // Functions
 export * from './lib/functions/utils';
+export * from './lib/functions/tag-build-contract';

--- a/libs/utils/src/lib/functions/tag-build-contract.ts
+++ b/libs/utils/src/lib/functions/tag-build-contract.ts
@@ -1,0 +1,324 @@
+import { TagTypeEnum } from '../enums/tag-build';
+import type {
+  GTMConfiguration,
+  Parameter,
+  ParameterListItem,
+  ParameterMap,
+  ParameterWithKeyValue,
+  TagConfig,
+  Trigger,
+  TriggerConfig,
+  VariableConfig
+} from '../types/tag-build';
+import type { Spec, StrictDataLayerEvent } from '../types/tag-check';
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === 'string')
+  );
+}
+
+export function isParameter(value: unknown): value is Parameter {
+  if (!isRecord(value) || typeof value['type'] !== 'string') {
+    return false;
+  }
+
+  if (
+    'key' in value &&
+    value['key'] !== undefined &&
+    typeof value['key'] !== 'string'
+  ) {
+    return false;
+  }
+
+  if (
+    'value' in value &&
+    value['value'] !== undefined &&
+    typeof value['value'] !== 'string'
+  ) {
+    return false;
+  }
+
+  if (
+    'list' in value &&
+    value['list'] !== undefined &&
+    !Array.isArray(value['list'])
+  ) {
+    return false;
+  }
+
+  return (
+    !Array.isArray(value['list']) || value['list'].every(isParameterListItem)
+  );
+}
+
+export function isParameterMap(value: unknown): value is ParameterMap {
+  return (
+    isRecord(value) &&
+    value['type'] === 'MAP' &&
+    Array.isArray(value['map']) &&
+    value['map'].every(isParameter)
+  );
+}
+
+export function isParameterListItem(
+  value: unknown
+): value is ParameterListItem {
+  if (isParameterMap(value)) {
+    return true;
+  }
+
+  if (!isRecord(value) || typeof value['type'] !== 'string') {
+    return false;
+  }
+
+  if (
+    'value' in value &&
+    value['value'] !== undefined &&
+    typeof value['value'] !== 'string'
+  ) {
+    return false;
+  }
+
+  if ('map' in value && value['map'] !== undefined) {
+    return Array.isArray(value['map']) && value['map'].every(isParameter);
+  }
+
+  return true;
+}
+
+export function isParameterWithKeyValue(
+  parameter: Parameter
+): parameter is ParameterWithKeyValue {
+  return (
+    typeof parameter.key === 'string' && typeof parameter.value === 'string'
+  );
+}
+
+export function getParameterListItems(
+  parameter: Parameter | null | undefined
+): ParameterListItem[] {
+  return Array.isArray(parameter?.list) ? parameter.list : [];
+}
+
+export function getParameterValue(
+  parameters: readonly Parameter[] | null | undefined,
+  key: string,
+  type?: string
+): string | undefined {
+  const parameter = parameters?.find(
+    (entry) => entry.key === key && (type ? entry.type === type : true)
+  );
+
+  return typeof parameter?.value === 'string' ? parameter.value : undefined;
+}
+
+export function getParameterMapValue(
+  item: ParameterListItem | null | undefined,
+  key: string
+): string | undefined {
+  if (!isParameterMap(item)) {
+    return undefined;
+  }
+
+  return getParameterValue(item.map, key);
+}
+
+export function isTrigger(value: unknown): value is Trigger {
+  return (
+    isRecord(value) &&
+    typeof value['name'] === 'string' &&
+    typeof value['triggerId'] === 'string'
+  );
+}
+
+export function isTriggerConfig(value: unknown): value is TriggerConfig {
+  if (
+    !isRecord(value) ||
+    typeof value['name'] !== 'string' ||
+    typeof value['type'] !== 'string' ||
+    typeof value['accountId'] !== 'string' ||
+    typeof value['containerId'] !== 'string'
+  ) {
+    return false;
+  }
+
+  if (
+    'triggerId' in value &&
+    value['triggerId'] !== undefined &&
+    typeof value['triggerId'] !== 'string'
+  ) {
+    return false;
+  }
+
+  if (
+    'firingTriggerId' in value &&
+    value['firingTriggerId'] !== undefined &&
+    !isStringArray(value['firingTriggerId'])
+  ) {
+    return false;
+  }
+
+  if (
+    'parameter' in value &&
+    value['parameter'] !== undefined &&
+    (!Array.isArray(value['parameter']) ||
+      !value['parameter'].every(isParameter))
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export function isTagConfig(value: unknown): value is TagConfig {
+  if (
+    !isRecord(value) ||
+    typeof value['name'] !== 'string' ||
+    typeof value['type'] !== 'string' ||
+    typeof value['accountId'] !== 'string' ||
+    typeof value['containerId'] !== 'string' ||
+    !Array.isArray(value['parameter']) ||
+    !value['parameter'].every(isParameter)
+  ) {
+    return false;
+  }
+
+  if (
+    'firingTriggerId' in value &&
+    value['firingTriggerId'] !== undefined &&
+    !isStringArray(value['firingTriggerId'])
+  ) {
+    return false;
+  }
+
+  if (
+    'tagFiringOption' in value &&
+    value['tagFiringOption'] !== undefined &&
+    typeof value['tagFiringOption'] !== 'string'
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export function isVariableConfig(value: unknown): value is VariableConfig {
+  if (
+    !isRecord(value) ||
+    typeof value['name'] !== 'string' ||
+    typeof value['type'] !== 'string' ||
+    typeof value['accountId'] !== 'string' ||
+    typeof value['containerId'] !== 'string'
+  ) {
+    return false;
+  }
+
+  if (
+    'parameter' in value &&
+    value['parameter'] !== undefined &&
+    (!Array.isArray(value['parameter']) ||
+      !value['parameter'].every(isParameter))
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export function isSpec(value: unknown): value is Spec {
+  return (
+    isRecord(value) &&
+    isTagConfig(value['tag']) &&
+    Array.isArray(value['trigger']) &&
+    value['trigger'].every(isTriggerConfig)
+  );
+}
+
+export function isSpecArray(value: unknown): value is Spec[] {
+  return Array.isArray(value) && value.every(isSpec);
+}
+
+export function isStrictDataLayerEvent(
+  value: unknown
+): value is StrictDataLayerEvent {
+  return isRecord(value) && typeof value['event'] === 'string';
+}
+
+export function isStrictDataLayerEventArray(
+  value: unknown
+): value is StrictDataLayerEvent[] {
+  return Array.isArray(value) && value.every(isStrictDataLayerEvent);
+}
+
+function isGTMContainerVersion(
+  value: unknown
+): value is GTMConfiguration['containerVersion'] {
+  return (
+    isRecord(value) &&
+    Array.isArray(value['variable']) &&
+    value['variable'].every(isVariableConfig) &&
+    Array.isArray(value['builtInVariable']) &&
+    value['builtInVariable'].every(isVariableConfig) &&
+    Array.isArray(value['trigger']) &&
+    value['trigger'].every(isTriggerConfig) &&
+    Array.isArray(value['tag']) &&
+    value['tag'].every(isTagConfig)
+  );
+}
+
+export function isGTMConfiguration(value: unknown): value is GTMConfiguration {
+  return (
+    isRecord(value) &&
+    typeof value['exportFormatVersion'] === 'number' &&
+    typeof value['exportTime'] === 'string' &&
+    isGTMContainerVersion(value['containerVersion'])
+  );
+}
+
+export function createPlaceholderTagConfig(input: {
+  name: string;
+  type?: TagConfig['type'];
+  accountId?: string;
+  containerId?: string;
+  parameter?: Parameter[];
+}): TagConfig {
+  return {
+    name: input.name,
+    type: input.type ?? TagTypeEnum.GAAWE,
+    accountId: input.accountId ?? '',
+    containerId: input.containerId ?? '',
+    parameter: input.parameter ?? []
+  };
+}
+
+export function createPlaceholderSpec(
+  tagName: string,
+  options: {
+    tag?: Partial<TagConfig>;
+    trigger?: TriggerConfig[];
+  } = {}
+): Spec {
+  const baseTag = createPlaceholderTagConfig({
+    name: tagName,
+    type: options.tag?.type,
+    accountId: options.tag?.accountId,
+    containerId: options.tag?.containerId,
+    parameter: options.tag?.parameter
+  });
+
+  return {
+    tag: {
+      ...baseTag,
+      ...options.tag,
+      parameter: options.tag?.parameter ?? baseTag.parameter
+    },
+    trigger: options.trigger ?? []
+  };
+}

--- a/libs/utils/src/lib/types/tag-build/common.type.ts
+++ b/libs/utils/src/lib/types/tag-build/common.type.ts
@@ -1,43 +1,37 @@
-import { Spec } from '../tag-check';
-
 export type NestedObject = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 };
 
 export type ParameterMap = {
-  type: string;
+  type: 'MAP';
   map: Parameter[];
 };
+
+export type ParameterListItem =
+  | ParameterMap
+  | {
+      type: string;
+      value?: string;
+      map?: Parameter[];
+    };
 
 export type Parameter = {
   type: string;
   // Some parameter objects (e.g. TRIGGER_REFERENCE list items) don't carry a key
   key?: string;
   value?: string;
-  // In GTM exports, list items can be either MAPs with nested parameters or
-  // simple references like TRIGGER_REFERENCE items with just a value.
-  list?: Array<
-    | ParameterMap
-    | {
-        type: string;
-        value?: string;
-        map?: Parameter[];
-      }
-  >;
+  list?: ParameterListItem[];
+};
+
+export type ParameterWithKeyValue = Parameter & {
+  key: string;
+  value: string;
 };
 
 export type CustomEventFilter = {
   type: string;
   parameter: Parameter[];
-};
-
-export type GTMContainerConfig = {
-  accountId: string;
-  containerId: string;
-  containerName: string;
-  gtmId: string;
-  specs: Spec[];
 };
 
 export type DataRow = {

--- a/libs/utils/src/lib/types/tag-build/tag.type.ts
+++ b/libs/utils/src/lib/types/tag-build/tag.type.ts
@@ -1,5 +1,4 @@
 import { TagTypeEnum } from '../../enums/tag-build';
-import { Spec, StrictDataLayerEvent } from '../tag-check';
 import { Parameter } from './common.type';
 import { Trigger } from './trigger.type';
 
@@ -53,10 +52,3 @@ export type GoogleTagConfig = {
 export type HTMLTagConfig = {
   type: TagTypeEnum.HTML;
 } & Omit<TagConfig, 'type'>;
-
-export type TagSpec = {
-  event: string;
-  eventName: string;
-  dataLayerSpec: StrictDataLayerEvent;
-  rawGtmTag: Spec;
-};

--- a/libs/utils/src/lib/types/tag-check/gtm-container-config.type.ts
+++ b/libs/utils/src/lib/types/tag-check/gtm-container-config.type.ts
@@ -1,0 +1,9 @@
+import { StrictDataLayerEvent } from './data-layer.type';
+
+export type GTMContainerConfig = {
+  accountId: string;
+  containerId: string;
+  containerName: string;
+  gtmId: string;
+  specs: StrictDataLayerEvent[];
+};

--- a/libs/utils/src/lib/types/tag-check/index.ts
+++ b/libs/utils/src/lib/types/tag-check/index.ts
@@ -7,6 +7,8 @@ export * from './project.type';
 export * from './recording.type';
 export * from './setting.type';
 export * from './spec.type';
+export * from './tag-spec.type';
+export * from './gtm-container-config.type';
 export * from './data-layer.type';
 export * from './auditable.type';
 export * from './file-report.type';

--- a/libs/utils/src/lib/types/tag-check/spec.type.ts
+++ b/libs/utils/src/lib/types/tag-check/spec.type.ts
@@ -4,7 +4,7 @@ import { StrictDataLayerEvent } from './data-layer.type';
 
 export type ProjectSpec = {
   projectSlug: string;
-  specs: Spec[];
+  specs: StrictDataLayerEvent[];
 };
 
 /**

--- a/libs/utils/src/lib/types/tag-check/tag-spec.type.ts
+++ b/libs/utils/src/lib/types/tag-check/tag-spec.type.ts
@@ -1,0 +1,5 @@
+import { DataLayerSpec } from './spec.type';
+
+export type TagSpec = DataLayerSpec & {
+  event: string;
+};


### PR DESCRIPTION
## What changed
- separated raw tag-build / GTM contracts from composite tag-check contracts while keeping stable `@utils` re-exports
- added shared contract guards/helpers for GTM parsing, parameter access, and placeholder spec creation
- refactored frontend, backend, and data-access consumers to use the new helper layer instead of cast-heavy parameter access
- normalized uploaded spec JSON handling to `StrictDataLayerEvent[]`
- centralized example-project spec construction for event fixtures
- aligned `apps/ng-tag-build/tsconfig.json` with workspace module resolution so the app builds cleanly
- preserved existing saved GTM files on invalid backend uploads instead of overwriting them with `{}`

## Why
This refactor tightens the shared contract layer used by tag-build and tag-check so we get clearer ownership of types, safer parsing, and less repetitive casting without intentionally changing GTM/spec payload formats.

## Impact
- improves type safety around GTM JSON parsing and parameter extraction
- keeps top-level `@utils` imports stable for existing consumers
- reduces regression risk in tag-build/tag-check contract handling across frontend and backend paths

## Validation
- `pnpm nx test data-access --experimental-vm-modules`
- `pnpm nx build ng-tag-build`
- `pnpm nx build ng-frontend`
- `pnpm nx build nest-backend`
- `pnpm review:test`
- `pnpm review:implementation`
