### PR TITLE
[codex] Clarify ng-product-doc shared UI boundaries

### DIFF
--- a/apps/ng-product-doc/src/app/app.component.ts
+++ b/apps/ng-product-doc/src/app/app.component.ts
@@ -1,7 +1,86 @@
-import { Component, Inject, LOCALE_ID, OnInit } from '@angular/core';
-import { Router, RouterOutlet } from '@angular/router';
+import { Component, inject, LOCALE_ID, OnInit } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
 import { AsyncPipe, NgComponentOutlet } from '@angular/common';
-import { Meta } from '@angular/platform-browser';
+import { Meta, type MetaDefinition } from '@angular/platform-browser';
+import type { ToolbarInputs } from '@ui';
+
+const PRODUCT_DOC_META_TAGS: MetaDefinition[] = [
+  {
+    name: 'description',
+    content:
+      'TagCheck validates your GTM configuration to ensure accurate data measurement. Help digital marketers focus on insights rather than technical setup, reducing errors and streamlining tag management.'
+  },
+  // Keywords are less important for Google but kept for other engines.
+  {
+    name: 'keywords',
+    content:
+      'GTM Validation, Tag Audit, Google Tag Manager, TagCheck, Data Measurement, Tag Quality Assurance, Digital Analytics, Marketing Tags'
+  },
+  {
+    name: 'viewport',
+    content: 'width=device-width, initial-scale=1'
+  },
+  {
+    rel: 'canonical',
+    href: 'https://tag-check-documentation.vercel.app'
+  },
+  {
+    property: 'og:title',
+    content: 'TagCheck | GTM Validation & Audit Tool for Digital Marketers'
+  },
+  {
+    property: 'og:description',
+    content:
+      'Validate your GTM setup with TagCheck. Ensure accurate data measurement, reduce implementation errors, and focus on insights rather than technical configuration.'
+  },
+  {
+    property: 'og:url',
+    content: 'https://tag-check-documentation.vercel.app'
+  },
+  {
+    property: 'og:type',
+    content: 'website'
+  },
+  {
+    property: 'og:image',
+    content:
+      'https://tag-check-documentation.vercel.app/assets/images/tagcheck-og.png'
+  },
+  {
+    property: 'og:image:width',
+    content: '1200'
+  },
+  {
+    property: 'og:image:height',
+    content: '630'
+  },
+  {
+    name: 'twitter:card',
+    content: 'summary_large_image'
+  },
+  {
+    name: 'twitter:title',
+    content: 'TagCheck | GTM Validation & Audit Tool for Digital Marketers'
+  },
+  {
+    name: 'twitter:description',
+    content:
+      'Validate your GTM setup with TagCheck. Ensure accurate data measurement, reduce implementation errors, and focus on insights rather than technical configuration.'
+  },
+  {
+    name: 'twitter:image',
+    content:
+      'https://tag-check-documentation.vercel.app/assets/images/tagcheck-og.png'
+  },
+  {
+    'http-equiv': 'content-language',
+    content: 'en'
+  },
+  {
+    name: 'author',
+    content: 'TagCheck Team'
+  }
+];
 
 @Component({
   imports: [RouterOutlet, NgComponentOutlet, AsyncPipe],
@@ -43,23 +122,19 @@ import { Meta } from '@angular/platform-browser';
   ]
 })
 export class AppComponent implements OnInit {
+  private readonly metaService = inject(Meta);
+
   title = 'TagCheck';
   toolbarComponent = this.loadToolbarComponent();
   footerComponent = this.loadFooterComponent();
+  readonly locale = inject(LOCALE_ID);
   toolbarInputs = {
     title: this.title,
     aboutDisabled: true,
     objectivesDisabled: false
-  };
-
-  constructor(
-    private readonly router: Router,
-    private readonly metaService: Meta,
-    @Inject(LOCALE_ID) public locale: string
-  ) {}
+  } satisfies ToolbarInputs;
 
   ngOnInit() {
-    this.router.navigate(['/documentation']);
     this.addMetaTags();
   }
 
@@ -79,88 +154,6 @@ export class AppComponent implements OnInit {
   }
 
   addMetaTags(): void {
-    this.metaService.addTags([
-      {
-        name: 'description',
-        content:
-          'TagCheck validates your GTM configuration to ensure accurate data measurement. Help digital marketers focus on insights rather than technical setup, reducing errors and streamlining tag management.'
-      },
-      // Keywords (less important for Google but kept for other engines)
-      {
-        name: 'keywords',
-        content:
-          'GTM Validation, Tag Audit, Google Tag Manager, TagCheck, Data Measurement, Tag Quality Assurance, Digital Analytics, Marketing Tags'
-      },
-      // Essential viewport tag for mobile optimization
-      {
-        name: 'viewport',
-        content: 'width=device-width, initial-scale=1'
-      },
-      // Canonical URL with proper format
-      {
-        rel: 'canonical',
-        href: 'https://tag-check-documentation.vercel.app'
-      },
-      // Open Graph tags for social sharing
-      {
-        property: 'og:title',
-        content: 'TagCheck | GTM Validation & Audit Tool for Digital Marketers'
-      },
-      {
-        property: 'og:description',
-        content:
-          'Validate your GTM setup with TagCheck. Ensure accurate data measurement, reduce implementation errors, and focus on insights rather than technical configuration.'
-      },
-      {
-        property: 'og:url',
-        content: 'https://tag-check-documentation.vercel.app'
-      },
-      {
-        property: 'og:type',
-        content: 'website'
-      },
-      {
-        property: 'og:image',
-        content:
-          'https://tag-check-documentation.vercel.app/assets/images/tagcheck-og.png'
-      },
-      {
-        property: 'og:image:width',
-        content: '1200'
-      },
-      {
-        property: 'og:image:height',
-        content: '630'
-      },
-      // Twitter Card tags
-      {
-        name: 'twitter:card',
-        content: 'summary_large_image'
-      },
-      {
-        name: 'twitter:title',
-        content: 'TagCheck | GTM Validation & Audit Tool for Digital Marketers'
-      },
-      {
-        name: 'twitter:description',
-        content:
-          'Validate your GTM setup with TagCheck. Ensure accurate data measurement, reduce implementation errors, and focus on insights rather than technical configuration.'
-      },
-      {
-        name: 'twitter:image',
-        content:
-          'https://tag-check-documentation.vercel.app/assets/images/tagcheck-og.png'
-      },
-      // Language specification
-      {
-        'http-equiv': 'content-language',
-        content: 'en'
-      },
-      // Optional: Add author information
-      {
-        name: 'author',
-        content: 'TagCheck Team'
-      }
-    ]);
+    this.metaService.addTags(PRODUCT_DOC_META_TAGS);
   }
 }

--- a/apps/ng-product-doc/src/app/app.routes.spec.ts
+++ b/apps/ng-product-doc/src/app/app.routes.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { appRoutes } from './app.routes';
+
+describe('appRoutes', () => {
+  it('uses declarative redirects for the product documentation entry routes', () => {
+    expect(appRoutes).toContainEqual({
+      path: '',
+      redirectTo: 'documentation/introduction',
+      pathMatch: 'full'
+    });
+    expect(appRoutes).toContainEqual({
+      path: '**',
+      redirectTo: 'documentation/introduction'
+    });
+  });
+});

--- a/apps/ng-tag-build/src/app/app.component.ts
+++ b/apps/ng-tag-build/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { AsyncPipe, NgComponentOutlet } from '@angular/common';
 import { Component, Inject, LOCALE_ID, OnInit } from '@angular/core';
 import { Meta } from '@angular/platform-browser';
 import { RouterOutlet } from '@angular/router';
+import type { ToolbarInputs } from '@ui';
 
 @Component({
   selector: 'app-root',
@@ -44,7 +45,7 @@ export class AppComponent implements OnInit {
   title = 'Tag Build';
   toolbarComponent = this.loadToolbarComponent();
   footerComponent = this.loadFooterComponent();
-  toolbarInputs = { title: this.title };
+  toolbarInputs = { title: this.title } satisfies ToolbarInputs;
 
   constructor(
     private readonly metaService: Meta,

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -1,16 +1,4 @@
-// tag build components
-export * from './lib/views/tag-build-page/tag-build-page.component';
-export * from './lib/components/about/about.component';
-export * from './lib/components/objectives/objectives.component';
-export * from './lib/components/toolbar/toolbar.component';
-export * from './lib/components/footer/footer.component';
-
-// shared components
-export * from './lib/components/error-dialog/error-dialog.component';
-export * from './lib/components/progress-spinner/progress-spinner.component';
-export * from './lib/components/custom-mat-table/custom-mat-table.component';
-export * from './lib/components/editor/editor.component';
-
-// modules
-export * from './lib/modules/tag-build-app/tag-build-app.component';
-export * from './lib/modules/documentation/routes';
+export * from './lib/public-api/documentation';
+export * from './lib/public-api/shared-chrome';
+export * from './lib/public-api/shared-components';
+export * from './lib/public-api/tag-build';

--- a/libs/ui/src/lib/components/toolbar/toolbar.component.spec.ts
+++ b/libs/ui/src/lib/components/toolbar/toolbar.component.spec.ts
@@ -1,0 +1,95 @@
+import '@angular/localize/init';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed, type ComponentFixture } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ToolBarComponent, type ToolbarInputs } from '../../../index';
+
+describe('ToolbarInputs', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ToolBarComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations()
+      ]
+    }).compileComponents();
+  });
+
+  it('supports the minimal toolbar contract', () => {
+    const inputs: ToolbarInputs = { title: 'Tag Build' };
+    const fixture = renderToolbar(inputs);
+    const [aboutLink, objectivesLink] = getMenuLinks(fixture);
+
+    expect(fixture.componentInstance.title()).toBe('Tag Build');
+    expect(fixture.componentInstance.aboutDisabled()).toBe(false);
+    expect(fixture.componentInstance.objectivesDisabled()).toBe(false);
+    expect(aboutLink.classList.contains('hidden')).toBe(false);
+    expect(objectivesLink.classList.contains('hidden')).toBe(false);
+  });
+
+  it('supports optional toolbar visibility flags', () => {
+    const inputs: ToolbarInputs = {
+      title: 'TagCheck',
+      aboutDisabled: true,
+      objectivesDisabled: false
+    };
+    const fixture = renderToolbar(inputs);
+    const [aboutLink, objectivesLink] = getMenuLinks(fixture);
+
+    expect(fixture.componentInstance.title()).toBe('TagCheck');
+    expect(fixture.componentInstance.aboutDisabled()).toBe(true);
+    expect(fixture.componentInstance.objectivesDisabled()).toBe(false);
+    expect(aboutLink.classList.contains('hidden')).toBe(true);
+    expect(objectivesLink.classList.contains('hidden')).toBe(false);
+  });
+
+  it('hides both optional tabs when both visibility flags are true', () => {
+    const inputs: ToolbarInputs = {
+      title: 'TagCheck',
+      aboutDisabled: true,
+      objectivesDisabled: true
+    };
+    const fixture = renderToolbar(inputs);
+    const [aboutLink, objectivesLink] = getMenuLinks(fixture);
+
+    expect(aboutLink.classList.contains('hidden')).toBe(true);
+    expect(objectivesLink.classList.contains('hidden')).toBe(true);
+  });
+});
+
+function renderToolbar(
+  inputs: ToolbarInputs
+): ComponentFixture<ToolBarComponent> {
+  const fixture = TestBed.createComponent(ToolBarComponent);
+
+  fixture.componentRef.setInput('title', inputs.title);
+  if ('aboutDisabled' in inputs) {
+    fixture.componentRef.setInput('aboutDisabled', inputs.aboutDisabled);
+  }
+  if ('objectivesDisabled' in inputs) {
+    fixture.componentRef.setInput(
+      'objectivesDisabled',
+      inputs.objectivesDisabled
+    );
+  }
+  fixture.detectChanges();
+
+  return fixture;
+}
+
+function getMenuLinks(
+  fixture: ComponentFixture<ToolBarComponent>
+): HTMLAnchorElement[] {
+  const links = Array.from(
+    fixture.nativeElement.querySelectorAll('lib-menu-tabs a')
+  ) as HTMLAnchorElement[];
+
+  expect(links).toHaveLength(3);
+
+  return links;
+}

--- a/libs/ui/src/lib/components/toolbar/toolbar.component.ts
+++ b/libs/ui/src/lib/components/toolbar/toolbar.component.ts
@@ -7,6 +7,12 @@ import { MenuTabsComponent } from '../menu-tabs/menu-tabs.component';
 import { RouterLink } from '@angular/router';
 import { LangSelectComponent } from '../lang-select/lang-select.component';
 
+export interface ToolbarInputs {
+  title: string;
+  aboutDisabled?: boolean;
+  objectivesDisabled?: boolean;
+}
+
 @Component({
   selector: 'lib-toolbar',
   standalone: true,

--- a/libs/ui/src/lib/modules/documentation/routes.spec.ts
+++ b/libs/ui/src/lib/modules/documentation/routes.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { DOCS_ROUTES } from './routes';
+import { treeNodeDeactivateGuard } from './guards/documentation.guard';
+import { treeNodeResolver } from './resolvers/documentation.resolver';
+
+describe('DOCS_ROUTES', () => {
+  it('redirects the documentation shell index to introduction', () => {
+    const shellRoute = requireDefined(
+      DOCS_ROUTES.find((route) => route.path === ''),
+      'Expected the documentation shell route to exist.'
+    );
+    const shellChildren = shellRoute.children ?? [];
+    const redirectRoute = shellChildren.find((route) => route.path === '');
+
+    expect(
+      requireDefined(
+        redirectRoute,
+        'Expected the documentation shell route to have an index redirect.'
+      )
+    ).toMatchObject({
+      path: '',
+      redirectTo: 'introduction',
+      pathMatch: 'full'
+    });
+  });
+
+  it('keeps the markdown content route inside the documentation shell', () => {
+    const shellRoute = requireDefined(
+      DOCS_ROUTES.find((route) => route.path === ''),
+      'Expected the documentation shell route to exist.'
+    );
+    const shellChildren = shellRoute.children ?? [];
+    const contentRoute = requireDefined(
+      shellChildren.find((route) => route.path === ':name'),
+      'Expected the documentation shell route to include the markdown route.'
+    );
+
+    expect(shellRoute.loadComponent).toBeDefined();
+    expect(contentRoute.loadComponent).toBeDefined();
+    expect(contentRoute.resolve?.['data']).toBe(treeNodeResolver);
+    expect(contentRoute.canDeactivate).toContain(treeNodeDeactivateGuard);
+  });
+});
+
+function requireDefined<T>(value: T | undefined, message: string): T {
+  if (value === undefined) {
+    throw new Error(message);
+  }
+
+  return value;
+}

--- a/libs/ui/src/lib/modules/documentation/routes.ts
+++ b/libs/ui/src/lib/modules/documentation/routes.ts
@@ -11,6 +11,11 @@ export const DOCS_ROUTES: Routes = [
       ),
     children: [
       {
+        path: '',
+        redirectTo: 'introduction',
+        pathMatch: 'full'
+      },
+      {
         path: ':name',
         loadComponent: () =>
           import('./components/main-content/main-content.component').then(

--- a/libs/ui/src/lib/modules/documentation/views/documentation-view.component.ts
+++ b/libs/ui/src/lib/modules/documentation/views/documentation-view.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { SideBarComponent } from '../components/sidebar/sidebar.component';
-import { Router, RouterOutlet } from '@angular/router';
+import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-documentation-view',
@@ -39,9 +39,4 @@ import { Router, RouterOutlet } from '@angular/router';
     `
   ]
 })
-export class HelpCenterViewComponent implements OnInit {
-  constructor(private readonly router: Router) {}
-  ngOnInit(): void {
-    this.router.navigate(['/documentation/introduction']);
-  }
-}
+export class HelpCenterViewComponent {}

--- a/libs/ui/src/lib/public-api/documentation.ts
+++ b/libs/ui/src/lib/public-api/documentation.ts
@@ -1,0 +1,1 @@
+export * from '../modules/documentation/routes';

--- a/libs/ui/src/lib/public-api/shared-chrome.ts
+++ b/libs/ui/src/lib/public-api/shared-chrome.ts
@@ -1,0 +1,4 @@
+export * from '../components/about/about.component';
+export * from '../components/footer/footer.component';
+export * from '../components/objectives/objectives.component';
+export * from '../components/toolbar/toolbar.component';

--- a/libs/ui/src/lib/public-api/shared-components.ts
+++ b/libs/ui/src/lib/public-api/shared-components.ts
@@ -1,0 +1,4 @@
+export * from '../components/custom-mat-table/custom-mat-table.component';
+export * from '../components/editor/editor.component';
+export * from '../components/error-dialog/error-dialog.component';
+export * from '../components/progress-spinner/progress-spinner.component';

--- a/libs/ui/src/lib/public-api/tag-build.ts
+++ b/libs/ui/src/lib/public-api/tag-build.ts
@@ -1,0 +1,2 @@
+export * from '../modules/tag-build-app/tag-build-app.component';
+export * from '../views/tag-build-page/tag-build-page.component';

--- a/libs/ui/tsconfig.spec.json
+++ b/libs/ui/tsconfig.spec.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
     "target": "es2020",
-    "types": ["node", "vitest/globals"],
-    "composite": true,
-    "declaration": true
+    "types": ["node", "vitest/globals"]
   },
   "files": [],
   "include": [


### PR DESCRIPTION
## Summary
- Groups the `@ui` public API into documentation, shared chrome, shared components, and tag-build barrels while preserving existing `@ui` consumers.
- Adds a `ToolbarInputs` contract and wires `ng-product-doc` / `ng-tag-build` toolbar inputs through `satisfies ToolbarInputs` for safer dynamic component inputs.
- Moves `ng-product-doc` documentation default navigation into route config, removes app-level forced navigation, and extracts static meta tags.
- Adds route and toolbar regression tests; fixes the `ui` spec tsconfig so Vitest actually registers UI tests.

## Validation
- `pnpm nx run ui:test`
- `pnpm nx run ng-product-doc:test --skipNxCache`
- `pnpm nx run ui:lint` (passes with existing warnings)
- `pnpm nx run ng-product-doc:lint` (passes with existing warning)
- `pnpm nx run ng-product-doc:build:development`
- `pnpm nx run ng-tag-build:build:development`
- `pnpm nx run ng-frontend:build:development`
- Commit hook also ran lint-staged and the broader coverage test flow successfully.

## Notes
- This branch was created from `origin/develop` after opening #425, so this PR contains only the ng-product-doc shared UI refactor/fix.