### PR TITLE
refactor(ng-tag-build): 6-phase optimization — tests, fixes, cleanup, consent status

### DIFF
--- a/apps/ng-tag-build/src/app/app.config.ts
+++ b/apps/ng-tag-build/src/app/app.config.ts
@@ -7,12 +7,13 @@ import {
 } from '@angular/router';
 import { routes } from './app.routes';
 
-const appLang = localStorage.getItem('locale') || 'en';
-
 export const appConfig: ApplicationConfig = {
   providers: [
     provideHttpClient(), // required
     provideRouter(routes, withPreloading(PreloadAllModules)),
-    { provide: LOCALE_ID, useValue: appLang }
+    {
+      provide: LOCALE_ID,
+      useFactory: () => localStorage.getItem('locale') || 'en'
+    }
   ]
 };

--- a/libs/data-access/src/lib/services/editor-facade/editor-facade.service.ts
+++ b/libs/data-access/src/lib/services/editor-facade/editor-facade.service.ts
@@ -71,7 +71,7 @@ export class EditorFacadeService {
   updateJsonForEvents(
     json: any[],
     shouldInclude: boolean,
-    eventNames: string[]
+    eventNames: ReadonlyArray<string>
   ) {
     for (const eventName of eventNames) {
       const eventIndex = json.findIndex(

--- a/libs/data-access/src/lib/services/editor-facade/editor-facade.service.ts
+++ b/libs/data-access/src/lib/services/editor-facade/editor-facade.service.ts
@@ -2,6 +2,10 @@
 import { Injectable } from '@angular/core';
 import { EditorService } from '../editor/editor.service';
 import { EditorTypeEnum } from '@utils';
+import {
+  BUILT_IN_SCROLL_EVENT,
+  BUILT_IN_VIDEO_EVENTS
+} from '../gtm-json-converter/transform/utils/constant';
 
 @Injectable({
   providedIn: 'root'
@@ -34,17 +38,12 @@ export class EditorFacadeService {
 
   hasVideoTag(json: any) {
     if (!Array.isArray(json)) return false;
-    return json.some(
-      (item: any) =>
-        item.event === 'video_start' ||
-        item.event === 'video_progress' ||
-        item.event === 'video_complete'
-    );
+    return json.some((item: any) => BUILT_IN_VIDEO_EVENTS.includes(item.event));
   }
 
   hasScrollTag(json: any) {
     if (!Array.isArray(json)) return false;
-    return json.some((item: any) => item.event === 'scroll');
+    return json.some((item: any) => BUILT_IN_SCROLL_EVENT.includes(item.event));
   }
 
   updateJsonBasedOnForm(
@@ -57,8 +56,8 @@ export class EditorFacadeService {
   ): any {
     // Configuration object to map form properties to their respective events
     const eventConfig = {
-      includeVideoTag: ['video_start', 'video_progress', 'video_completion'],
-      includeScrollTag: ['scroll']
+      includeVideoTag: BUILT_IN_VIDEO_EVENTS as readonly string[],
+      includeScrollTag: BUILT_IN_SCROLL_EVENT as readonly string[]
       // more mappings can be added here in the future...
     };
 

--- a/libs/data-access/src/lib/services/gtm-json-converter/extract/spec-extract.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/extract/spec-extract.service.spec.ts
@@ -93,4 +93,101 @@ describe('SpecExtractService', () => {
         ]`)
     ).toThrow('Error parsing spec JSON. Please check the format.');
   });
+
+  describe('fixJsonString edge cases', () => {
+    it('should repair nested objects with unquoted keys', () => {
+      const input = '{ event: page_view, params: { key: value } }';
+      const result = service.fixJsonString(input);
+      const parsed = JSON.parse(result);
+      expect(parsed).toEqual({
+        event: 'page_view',
+        params: { key: 'value' }
+      });
+    });
+
+    it('should preserve boolean and null literals without quoting them', () => {
+      const input = '{ active: true, count: 0, empty: null }';
+      const result = service.fixJsonString(input);
+      const parsed = JSON.parse(result);
+      expect(parsed.active).toBe(true);
+      expect(parsed.empty).toBe(null);
+      // Note: numeric 0 becomes "0" — the regex-based repair cannot
+      // distinguish numeric literals from unquoted string values.
+    });
+
+    it('should repair multiple trailing commas in nested arrays and objects', () => {
+      const input = '[{ event: page_view, }, { event: purchase, },]';
+      const result = service.fixJsonString(input);
+      const parsed = JSON.parse(result);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].event).toBe('page_view');
+      expect(parsed[1].event).toBe('purchase');
+    });
+
+    it('should handle empty objects and arrays', () => {
+      const input = '{ items: [], meta: {} }';
+      const result = service.fixJsonString(input);
+      const parsed = JSON.parse(result);
+      expect(parsed.items).toEqual([]);
+      expect(parsed.meta).toEqual({});
+    });
+
+    it('should handle unquoted numeric values (treated as strings by repair)', () => {
+      // The regex repair treats all unquoted values as strings.
+      // This is a known limitation; users should quote values explicitly.
+      const input = '{ event: purchase, value: 799.99, quantity: 3 }';
+      const result = service.fixJsonString(input);
+      const parsed = JSON.parse(result);
+      // Numbers become strings after repair
+      expect(typeof parsed.value).toBe('string');
+      expect(parsed.value).toBe('799.99');
+      expect(parsed.quantity).toBe('3');
+    });
+
+    it('should handle single-quoted keys and values in nested structures', () => {
+      const input =
+        "[{ 'event': 'page_view', 'ecommerce': { 'value': '799' } }]";
+      const result = service.fixJsonString(input);
+      const parsed = JSON.parse(result);
+      expect(parsed[0].event).toBe('page_view');
+      expect(parsed[0].ecommerce.value).toBe('799');
+    });
+
+    it('should repair unquoted single-word values even with mixed quoting', () => {
+      const input = '{ "event": page_view, "value": 100 }';
+      const result = service.fixJsonString(input);
+      const parsed = JSON.parse(result);
+      expect(parsed.event).toBe('page_view');
+      // Numbers become strings through regex repair
+      expect(parsed.value).toBe('100');
+    });
+
+    it('should repair a realistic multi-event spec with various issues', () => {
+      // Note: unquoted values with spaces (like "Product A") are NOT repaired
+      // by the current regex. Use single-quoted or double-quoted values instead.
+      const input = `[
+        {
+          event: page_view,
+          page_location: /home, // comment
+          page_title: 'Welcome',
+        },
+        {
+          event: purchase,
+          ecommerce: {
+            value: 799.99,
+            currency: TWD,
+            items: [
+              { item_name: 'Product A', quantity: 1, },
+            ],
+          }
+        }
+      ]`;
+      const result = service.fixJsonString(input);
+      const parsed = JSON.parse(result);
+      expect(parsed).toHaveLength(2);
+      // Numbers become strings through repair
+      expect(parsed[1].ecommerce.value).toBe('799.99');
+      expect(parsed[1].ecommerce.items[0].item_name).toBe('Product A');
+    });
+  });
 });

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/config-manager.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/config-manager.service.spec.ts
@@ -64,7 +64,7 @@ describe('ConfigManager', () => {
     firingTriggerId: ['2147479553'],
     tagFiringOption: 'ONCE_PER_EVENT',
     monitoringMetadata: { type: 'MAP' },
-    consentSettings: { consentStatus: 'NOT_SET' }
+    consentSettings: { consentStatus: 'NOT_NEEDED' }
   };
 
   beforeEach(() => {

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/config-manager.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/config-manager.service.spec.ts
@@ -1,0 +1,254 @@
+import { TestBed } from '@angular/core/testing';
+import { ConfigManager } from './config-manager.service';
+import { UtilsService } from '../../utils/utils.service';
+import type { TagConfig, TriggerConfig, VariableConfig } from '@utils';
+
+describe('ConfigManager', () => {
+  let service: ConfigManager;
+  let utilsService: UtilsService;
+
+  const mockAccountId = '123456';
+  const mockContainerId = '789012';
+  const mockContainerName = 'Test Container';
+  const mockGtmId = 'GTM-XXXXXX';
+
+  const mockVariable: VariableConfig = {
+    name: 'DLV - page_location',
+    type: 'v',
+    accountId: mockAccountId,
+    containerId: mockContainerId,
+    parameter: [
+      { type: 'INTEGER', key: 'dataLayerVersion', value: '2' },
+      { type: 'BOOLEAN', key: 'setDefaultValue', value: 'false' },
+      { type: 'TEMPLATE', key: 'name', value: 'page_location' }
+    ]
+  };
+
+  const mockBuiltInVariable: VariableConfig = {
+    name: 'Page URL',
+    type: 'PAGE_URL',
+    accountId: mockAccountId,
+    containerId: mockContainerId
+  };
+
+  const mockTrigger: TriggerConfig = {
+    name: 'event equals page_view',
+    type: 'CUSTOM_EVENT',
+    accountId: mockAccountId,
+    containerId: mockContainerId,
+    triggerId: '1',
+    customEventFilter: [
+      {
+        type: 'EQUALS',
+        parameter: [
+          { type: 'TEMPLATE', key: 'arg0', value: '{{_event}}' },
+          { type: 'TEMPLATE', key: 'arg1', value: 'page_view' }
+        ]
+      }
+    ]
+  };
+
+  const mockTag: TagConfig = {
+    name: 'Google Tag',
+    type: 'googtag',
+    accountId: mockAccountId,
+    containerId: mockContainerId,
+    tagId: '1',
+    parameter: [
+      {
+        type: 'TEMPLATE',
+        key: 'tagId',
+        value: '{{CONST - Measurement ID}}'
+      }
+    ],
+    firingTriggerId: ['2147479553'],
+    tagFiringOption: 'ONCE_PER_EVENT',
+    monitoringMetadata: { type: 'MAP' },
+    consentSettings: { consentStatus: 'NOT_SET' }
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ConfigManager, UtilsService]
+    });
+    service = TestBed.inject(ConfigManager);
+    utilsService = TestBed.inject(UtilsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getGTMFinalConfiguration', () => {
+    it('should produce a valid GTMConfiguration with exportFormatVersion 2', () => {
+      const result = service.getGTMFinalConfiguration({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        variables: [mockVariable],
+        builtInVariables: [mockBuiltInVariable],
+        triggers: [mockTrigger],
+        tags: [mockTag],
+        containerName: mockContainerName,
+        gtmId: mockGtmId
+      });
+
+      expect(result.exportFormatVersion).toBe(2);
+      expect(result.exportTime).toBeTruthy();
+      expect(typeof result.exportTime).toBe('string');
+    });
+
+    it('should wire accountId and containerId into all nested paths', () => {
+      const result = service.getGTMFinalConfiguration({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        variables: [],
+        builtInVariables: [],
+        triggers: [],
+        tags: [],
+        containerName: mockContainerName,
+        gtmId: mockGtmId
+      });
+
+      const cv = result.containerVersion;
+      expect(cv.path).toBe(
+        `accounts/${mockAccountId}/containers/${mockContainerId}/versions/0`
+      );
+      expect(cv.accountId).toBe(mockAccountId);
+      expect(cv.containerId).toBe(mockContainerId);
+      expect(cv.containerVersionId).toBe('0');
+      expect(cv.container.accountId).toBe(mockAccountId);
+      expect(cv.container.containerId).toBe(mockContainerId);
+    });
+
+    it('should populate the container with the provided name and gtmId', () => {
+      const result = service.getGTMFinalConfiguration({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        variables: [],
+        builtInVariables: [],
+        triggers: [],
+        tags: [],
+        containerName: mockContainerName,
+        gtmId: mockGtmId
+      });
+
+      expect(result.containerVersion.container.name).toBe(mockContainerName);
+      expect(result.containerVersion.container.publicId).toBe(mockGtmId);
+    });
+
+    it('should include variables, builtInVariables, triggers, and tags arrays', () => {
+      const result = service.getGTMFinalConfiguration({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        variables: [mockVariable],
+        builtInVariables: [mockBuiltInVariable],
+        triggers: [mockTrigger],
+        tags: [mockTag],
+        containerName: mockContainerName,
+        gtmId: mockGtmId
+      });
+
+      expect(result.containerVersion.variable).toEqual([mockVariable]);
+      expect(result.containerVersion.builtInVariable).toEqual([
+        mockBuiltInVariable
+      ]);
+      expect(result.containerVersion.trigger).toEqual([mockTrigger]);
+      expect(result.containerVersion.tag).toEqual([mockTag]);
+    });
+
+    it('should handle empty arrays gracefully', () => {
+      const result = service.getGTMFinalConfiguration({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        variables: [],
+        builtInVariables: [],
+        triggers: [],
+        tags: [],
+        containerName: mockContainerName,
+        gtmId: mockGtmId
+      });
+
+      expect(result.containerVersion.variable).toEqual([]);
+      expect(result.containerVersion.builtInVariable).toEqual([]);
+      expect(result.containerVersion.trigger).toEqual([]);
+      expect(result.containerVersion.tag).toEqual([]);
+    });
+
+    it('should include correct feature flags in the container', () => {
+      const result = service.getGTMFinalConfiguration({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        variables: [],
+        builtInVariables: [],
+        triggers: [],
+        tags: [],
+        containerName: mockContainerName,
+        gtmId: mockGtmId
+      });
+
+      const features = result.containerVersion.container.features;
+      expect(features.supportUserPermissions).toBe(true);
+      expect(features.supportEnvironments).toBe(true);
+      expect(features.supportWorkspaces).toBe(true);
+      expect(features.supportBuiltInVariables).toBe(true);
+      expect(features.supportTags).toBe(true);
+      expect(features.supportTriggers).toBe(true);
+      expect(features.supportVariables).toBe(true);
+      expect(features.supportVersions).toBe(true);
+      expect(features.supportFolders).toBe(true);
+      expect(features.supportTemplates).toBe(true);
+      expect(features.supportZones).toBe(true);
+    });
+
+    it('should set correct tagManagerUrl in both container and version', () => {
+      const result = service.getGTMFinalConfiguration({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        variables: [],
+        builtInVariables: [],
+        triggers: [],
+        tags: [],
+        containerName: mockContainerName,
+        gtmId: mockGtmId
+      });
+
+      const { container, tagManagerUrl } = result.containerVersion;
+      expect(container.tagManagerUrl).toContain(
+        `accounts/${mockAccountId}/containers/${mockContainerId}`
+      );
+      expect(tagManagerUrl).toContain(
+        `accounts/${mockAccountId}/containers/${mockContainerId}/versions/0`
+      );
+    });
+
+    it('should set usageContext to WEB', () => {
+      const result = service.getGTMFinalConfiguration({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        variables: [],
+        builtInVariables: [],
+        triggers: [],
+        tags: [],
+        containerName: mockContainerName,
+        gtmId: mockGtmId
+      });
+
+      expect(result.containerVersion.container.usageContext).toEqual(['WEB']);
+    });
+
+    it('should set tagIds on the container', () => {
+      const result = service.getGTMFinalConfiguration({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        variables: [],
+        builtInVariables: [],
+        triggers: [],
+        tags: [],
+        containerName: mockContainerName,
+        gtmId: mockGtmId
+      });
+
+      expect(result.containerVersion.container.tagIds).toEqual([mockGtmId]);
+    });
+  });
+});

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/config-manager.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/config-manager.service.ts
@@ -22,6 +22,36 @@ export interface GTMFinalConfigurationOptions {
   providedIn: 'root'
 })
 export class ConfigManager {
+  // --- GTM export constants ---
+  private static readonly EXPORT_FORMAT_VERSION = 2;
+  private static readonly CONTAINER_VERSION_ID = '0';
+  private static readonly USAGE_CONTEXT = ['WEB'] as const;
+
+  // Fingerprints are stable identifiers used by GTM exports
+  private static readonly CONTAINER_FINGERPRINT = '1690281340453';
+  private static readonly VERSION_FINGERPRINT = '1690374452646';
+
+  // Feature flags describing container capabilities
+  private static readonly DEFAULT_FEATURES = {
+    supportUserPermissions: true,
+    supportEnvironments: true,
+    supportWorkspaces: true,
+    supportGtagConfigs: false,
+    supportBuiltInVariables: true,
+    supportClients: false,
+    supportFolders: true,
+    supportTags: true,
+    supportTemplates: true,
+    supportTriggers: true,
+    supportVariables: true,
+    supportVersions: true,
+    supportZones: true,
+    supportTransformations: false
+  } as const;
+
+  private static readonly TAG_MANAGER_BASE_URL =
+    'https://tagmanager.google.com/#/container/accounts';
+
   constructor(private readonly utilsService: UtilsService) {}
 
   getGTMFinalConfiguration(
@@ -39,45 +69,30 @@ export class ConfigManager {
     } = options;
 
     return {
-      exportFormatVersion: 2,
+      exportFormatVersion: ConfigManager.EXPORT_FORMAT_VERSION,
       exportTime: this.utilsService.outputTime(),
       containerVersion: {
         path: `accounts/${accountId}/containers/${containerId}/versions/0`,
         accountId: `${accountId}`,
         containerId: `${containerId}`,
-        containerVersionId: '0',
+        containerVersionId: ConfigManager.CONTAINER_VERSION_ID,
         container: {
           path: `accounts/${accountId}/containers/${containerId}`,
           accountId: `${accountId}`,
           containerId: `${containerId}`,
           name: containerName,
           publicId: gtmId,
-          usageContext: ['WEB'],
-          fingerprint: '1690281340453',
-          tagManagerUrl: `https://tagmanager.google.com/#/container/accounts/${accountId}/containers/${containerId}/workspaces?apiLink=container`,
-          features: {
-            supportUserPermissions: true,
-            supportEnvironments: true,
-            supportWorkspaces: true,
-            supportGtagConfigs: false,
-            supportBuiltInVariables: true,
-            supportClients: false,
-            supportFolders: true,
-            supportTags: true,
-            supportTemplates: true,
-            supportTriggers: true,
-            supportVariables: true,
-            supportVersions: true,
-            supportZones: true,
-            supportTransformations: false
-          },
+          usageContext: [...ConfigManager.USAGE_CONTEXT],
+          fingerprint: ConfigManager.CONTAINER_FINGERPRINT,
+          tagManagerUrl: `${ConfigManager.TAG_MANAGER_BASE_URL}/${accountId}/containers/${containerId}/workspaces?apiLink=container`,
+          features: { ...ConfigManager.DEFAULT_FEATURES },
           tagIds: [gtmId]
         },
         variable: variables,
         builtInVariable: builtInVariables,
         trigger: triggers,
         tag: tags,
-        fingerprint: '1690374452646',
+        fingerprint: ConfigManager.VERSION_FINGERPRINT,
         tagManagerUrl: `https://tagmanager.google.com/#/versions/accounts/${accountId}/containers/${containerId}/versions/0?apiLink=version`
       }
     };

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/tag-manager.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/tag-manager.service.spec.ts
@@ -6,7 +6,6 @@ import { ScrollTag } from '../tags/scroll-tag.service';
 import { VideoTag } from '../tags/video-tag.service';
 import { EventUtils } from '../../utils/event-utils.service';
 import { ParameterUtils } from '../utils/parameter-utils.service';
-import { EcParamsService } from '../../utils/ec-params.service';
 import type { DataLayer, Trigger, TagConfig } from '@utils';
 
 describe('TagManager', () => {
@@ -26,8 +25,7 @@ describe('TagManager', () => {
         ScrollTag,
         VideoTag,
         EventUtils,
-        ParameterUtils,
-        EcParamsService
+        ParameterUtils
       ]
     });
     service = TestBed.inject(TagManager);

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/tag-manager.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/tag-manager.service.spec.ts
@@ -1,0 +1,184 @@
+import { TestBed } from '@angular/core/testing';
+import { TagManager } from './tag-manager.service';
+import { EventTag } from '../tags/event-tag.service';
+import { GoogleTag } from '../tags/google-tag.service';
+import { ScrollTag } from '../tags/scroll-tag.service';
+import { VideoTag } from '../tags/video-tag.service';
+import { EventUtils } from '../../utils/event-utils.service';
+import { ParameterUtils } from '../utils/parameter-utils.service';
+import { EcParamsService } from '../../utils/ec-params.service';
+import type { DataLayer, Trigger, TagConfig } from '@utils';
+
+describe('TagManager', () => {
+  let service: TagManager;
+
+  const mockAccountId = 'acc-tag';
+  const mockContainerId = 'con-tag';
+  const mockGoogleTagName = 'Google Tag';
+  const mockMeasurementId = 'G-XXXXXXXXXX';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        TagManager,
+        EventTag,
+        GoogleTag,
+        ScrollTag,
+        VideoTag,
+        EventUtils,
+        ParameterUtils,
+        EcParamsService
+      ]
+    });
+    service = TestBed.inject(TagManager);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getTags', () => {
+    it('should always include a Google Tag configuration as the first tag', () => {
+      const dataLayers: DataLayer[] = [];
+      const triggers: Trigger[] = [];
+
+      const result = service.getTags(
+        mockAccountId,
+        mockContainerId,
+        dataLayers,
+        triggers,
+        mockGoogleTagName,
+        mockMeasurementId,
+        'false'
+      );
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0].name).toBe(mockGoogleTagName);
+      expect(result[0].type).toBe('googtag');
+    });
+
+    it('should create event tags for each data layer event', () => {
+      const dataLayers: DataLayer[] = [
+        { event: 'page_view', paths: ['page_location'] },
+        { event: 'purchase', paths: ['value', 'currency'] }
+      ];
+      const triggers: Trigger[] = [
+        { name: 'page_view', triggerId: '1' },
+        { name: 'purchase', triggerId: '2' }
+      ];
+
+      const result = service.getTags(
+        mockAccountId,
+        mockContainerId,
+        dataLayers,
+        triggers,
+        mockGoogleTagName,
+        mockMeasurementId,
+        'false'
+      );
+
+      // 1 config tag + 2 event tags + scroll tags + video tags
+      const eventTags = result.filter((t) => t.name.startsWith('GA4 event'));
+      expect(eventTags).toHaveLength(2);
+    });
+
+    it('should assign sequential tagIds starting from "1"', () => {
+      const dataLayers: DataLayer[] = [{ event: 'page_view', paths: [] }];
+      const triggers: Trigger[] = [{ name: 'page_view', triggerId: '1' }];
+
+      const result = service.getTags(
+        mockAccountId,
+        mockContainerId,
+        dataLayers,
+        triggers,
+        mockGoogleTagName,
+        mockMeasurementId,
+        'false'
+      );
+
+      for (let i = 0; i < result.length; i++) {
+        expect(result[i].tagId).toBe(String(i + 1));
+      }
+    });
+
+    it('should include scroll and video tags in the output', () => {
+      const dataLayers: DataLayer[] = [{ event: 'page_view', paths: [] }];
+      const triggers: Trigger[] = [{ name: 'page_view', triggerId: '1' }];
+
+      const result = service.getTags(
+        mockAccountId,
+        mockContainerId,
+        dataLayers,
+        triggers,
+        mockGoogleTagName,
+        mockMeasurementId,
+        'false'
+      );
+
+      const tagNames = result.map((t) => t.name);
+      // Should include scroll and video tags (even if they may be empty arrays
+      // because the underlying services check data layers)
+      expect(tagNames).toEqual(
+        expect.arrayContaining([
+          'Google Tag',
+          expect.stringContaining('page_view')
+        ])
+      );
+    });
+
+    it('should propagate accountId and containerId to all tags', () => {
+      const dataLayers: DataLayer[] = [
+        { event: 'page_view', paths: ['page_location'] }
+      ];
+      const triggers: Trigger[] = [{ name: 'page_view', triggerId: '1' }];
+
+      const result = service.getTags(
+        mockAccountId,
+        mockContainerId,
+        dataLayers,
+        triggers,
+        mockGoogleTagName,
+        mockMeasurementId,
+        'false'
+      );
+
+      for (const tag of result) {
+        expect(tag.accountId).toBe(mockAccountId);
+        expect(tag.containerId).toBe(mockContainerId);
+      }
+    });
+
+    it('should handle empty data layers (should still produce Google Tag config)', () => {
+      const result = service.getTags(
+        mockAccountId,
+        mockContainerId,
+        [],
+        [],
+        mockGoogleTagName,
+        mockMeasurementId,
+        'false'
+      );
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0].type).toBe('googtag');
+    });
+
+    it('should create event tags with firingTriggerIds matching their triggers', () => {
+      const dataLayers: DataLayer[] = [{ event: 'purchase', paths: ['value'] }];
+      const triggers: Trigger[] = [{ name: 'purchase', triggerId: '42' }];
+
+      const result = service.getTags(
+        mockAccountId,
+        mockContainerId,
+        dataLayers,
+        triggers,
+        mockGoogleTagName,
+        mockMeasurementId,
+        'false'
+      );
+
+      const purchaseTag = result.find((t) => t.name === 'GA4 event - purchase');
+      expect(purchaseTag).toBeTruthy();
+    });
+  });
+});

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/tag-manager.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/tag-manager.service.spec.ts
@@ -117,10 +117,7 @@ describe('TagManager', () => {
 
       const tagNames = result.map((t) => t.name);
       expect(tagNames).toEqual(
-        expect.not.arrayContaining([
-          'GA4 event - scroll',
-          'GA4 event - Video'
-        ])
+        expect.not.arrayContaining(['GA4 event - scroll', 'GA4 event - Video'])
       );
     });
 
@@ -139,9 +136,7 @@ describe('TagManager', () => {
       );
 
       const tagNames = result.map((t) => t.name);
-      expect(tagNames).toEqual(
-        expect.arrayContaining(['GA4 event - scroll'])
-      );
+      expect(tagNames).toEqual(expect.arrayContaining(['GA4 event - scroll']));
     });
 
     it('should propagate accountId and containerId to all tags', () => {

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/tag-manager.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/tag-manager.service.spec.ts
@@ -99,8 +99,10 @@ describe('TagManager', () => {
       }
     });
 
-    it('should include scroll and video tags in the output', () => {
-      const dataLayers: DataLayer[] = [{ event: 'page_view', paths: [] }];
+    it('should NOT include scroll or video tags when no matching events exist', () => {
+      const dataLayers: DataLayer[] = [
+        { event: 'page_view', paths: ['page_location'] }
+      ];
       const triggers: Trigger[] = [{ name: 'page_view', triggerId: '1' }];
 
       const result = service.getTags(
@@ -114,13 +116,31 @@ describe('TagManager', () => {
       );
 
       const tagNames = result.map((t) => t.name);
-      // Should include scroll and video tags (even if they may be empty arrays
-      // because the underlying services check data layers)
       expect(tagNames).toEqual(
-        expect.arrayContaining([
-          'Google Tag',
-          expect.stringContaining('page_view')
+        expect.not.arrayContaining([
+          'GA4 event - scroll',
+          'GA4 event - Video'
         ])
+      );
+    });
+
+    it('should include scroll tag when data layers contain a scroll event', () => {
+      const dataLayers: DataLayer[] = [{ event: 'scroll', paths: [] }];
+      const triggers: Trigger[] = [{ name: 'scroll', triggerId: '99' }];
+
+      const result = service.getTags(
+        mockAccountId,
+        mockContainerId,
+        dataLayers,
+        triggers,
+        mockGoogleTagName,
+        mockMeasurementId,
+        'false'
+      );
+
+      const tagNames = result.map((t) => t.name);
+      expect(tagNames).toEqual(
+        expect.arrayContaining(['GA4 event - scroll'])
       );
     });
 

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/tag-manager.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/tag-manager.service.ts
@@ -88,13 +88,15 @@ export class TagManager {
       googleTagName,
       accountId,
       containerId,
-      triggers
+      triggers,
+      dataLayers
     );
     const scrollTags = this.scrollTag.createScrollTag(
       googleTagName,
       accountId,
       containerId,
-      triggers
+      triggers,
+      dataLayers
     );
 
     return [configTag, ...eventTags, ...videoTags, ...scrollTags];

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/trigger-manager.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/trigger-manager.service.spec.ts
@@ -92,11 +92,7 @@ describe('TriggerManager', () => {
       expect(eventTrigger?.type).toBe('CUSTOM_EVENT');
     });
 
-    it('should produce only event triggers when no video/scroll data layers exist', () => {
-      // NOTE: ScrollTrigger.createScrollTrigger and VideoTrigger.createVideoTrigger
-      // currently hardcode `const data = [] as any;` so they never produce triggers.
-      // When that bug is fixed, this test should be updated to expect scroll/video
-      // triggers when data layers contain those events.
+    it('should NOT include scroll/video triggers when no matching data layers exist', () => {
       const dataLayers: DataLayer[] = [{ event: 'page_view', paths: [] }];
 
       const result = service.getTriggers(
@@ -107,6 +103,45 @@ describe('TriggerManager', () => {
 
       const names = result.map((t) => t.name);
       expect(names).toEqual(['event equals page_view']);
+    });
+
+    it('should include scroll trigger when data layers contain a scroll event', () => {
+      const dataLayers: DataLayer[] = [
+        { event: 'page_view', paths: [] },
+        { event: 'scroll', paths: [] }
+      ];
+
+      const result = service.getTriggers(
+        mockAccountId,
+        mockContainerId,
+        dataLayers
+      );
+
+      const names = result.map((t) => t.name);
+      expect(names).toEqual(
+        expect.arrayContaining(['event equals page_view', 'event scroll'])
+      );
+    });
+
+    it('should include video trigger when data layers contain a video event', () => {
+      const dataLayers: DataLayer[] = [
+        { event: 'page_view', paths: [] },
+        { event: 'video_start', paths: [] }
+      ];
+
+      const result = service.getTriggers(
+        mockAccountId,
+        mockContainerId,
+        dataLayers
+      );
+
+      const names = result.map((t) => t.name);
+      expect(names).toEqual(
+        expect.arrayContaining([
+          'event equals page_view',
+          'event youtube video'
+        ])
+      );
     });
 
     it('should assign sequential triggerIds to all trigger configs', () => {
@@ -151,9 +186,7 @@ describe('TriggerManager', () => {
         dataLayers
       );
 
-      // Currently only event triggers are produced (3 total).
-      // Scroll/video triggers are disabled due to hardcoded empty data in
-      // ScrollTrigger.createScrollTrigger and VideoTrigger.createVideoTrigger.
+      // 3 event triggers (no scroll/video events in data layers)
       expect(result).toHaveLength(3);
     });
 

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/trigger-manager.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/trigger-manager.service.spec.ts
@@ -1,0 +1,177 @@
+import { TestBed } from '@angular/core/testing';
+import { TriggerManager } from './trigger-manager.service';
+import { EventTrigger } from '../triggers/event-trigger.service';
+import { VideoTrigger } from '../triggers/video-trigger.service';
+import { ScrollTrigger } from '../triggers/scroll-trigger.service';
+import { EventUtils } from '../../utils/event-utils.service';
+import { ParameterUtils } from '../utils/parameter-utils.service';
+import type { DataLayer, Trigger } from '@utils';
+
+describe('TriggerManager', () => {
+  let service: TriggerManager;
+
+  const mockAccountId = 'acc-trigger';
+  const mockContainerId = 'con-trigger';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        TriggerManager,
+        EventTrigger,
+        VideoTrigger,
+        ScrollTrigger,
+        EventUtils,
+        ParameterUtils
+      ]
+    });
+    service = TestBed.inject(TriggerManager);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('createTriggers', () => {
+    it('should create simple triggers with names matching event names', () => {
+      const dataLayers: DataLayer[] = [
+        { event: 'page_view', paths: [] },
+        { event: 'purchase', paths: ['value'] }
+      ];
+
+      const result = service.createTriggers(dataLayers);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('page_view');
+      expect(result[1].name).toBe('purchase');
+    });
+
+    it('should assign sequential triggerIds starting from "1"', () => {
+      const dataLayers: DataLayer[] = [
+        { event: 'page_view', paths: [] },
+        { event: 'purchase', paths: [] }
+      ];
+
+      const result = service.createTriggers(dataLayers);
+
+      expect(result[0].triggerId).toBe('1');
+      expect(result[1].triggerId).toBe('2');
+    });
+
+    it('should return empty array for empty data layers', () => {
+      const result = service.createTriggers([]);
+      expect(result).toEqual([]);
+    });
+
+    it('should create triggers with both name and triggerId properties', () => {
+      const dataLayers: DataLayer[] = [{ event: 'sign_up', paths: [] }];
+
+      const result = service.createTriggers(dataLayers);
+
+      expect(result[0]).toHaveProperty('name');
+      expect(result[0]).toHaveProperty('triggerId');
+      expect(result[0].name).toBe('sign_up');
+      expect(typeof result[0].triggerId).toBe('string');
+    });
+  });
+
+  describe('getTriggers', () => {
+    it('should create event trigger configs for each data layer event', () => {
+      const dataLayers: DataLayer[] = [{ event: 'page_view', paths: [] }];
+
+      const result = service.getTriggers(
+        mockAccountId,
+        mockContainerId,
+        dataLayers
+      );
+
+      expect(result.length).toBeGreaterThanOrEqual(1);
+      const eventTrigger = result.find(
+        (t) => t.name === 'event equals page_view'
+      );
+      expect(eventTrigger).toBeTruthy();
+      expect(eventTrigger?.type).toBe('CUSTOM_EVENT');
+    });
+
+    it('should produce only event triggers when no video/scroll data layers exist', () => {
+      // NOTE: ScrollTrigger.createScrollTrigger and VideoTrigger.createVideoTrigger
+      // currently hardcode `const data = [] as any;` so they never produce triggers.
+      // When that bug is fixed, this test should be updated to expect scroll/video
+      // triggers when data layers contain those events.
+      const dataLayers: DataLayer[] = [{ event: 'page_view', paths: [] }];
+
+      const result = service.getTriggers(
+        mockAccountId,
+        mockContainerId,
+        dataLayers
+      );
+
+      const names = result.map((t) => t.name);
+      expect(names).toEqual(['event equals page_view']);
+    });
+
+    it('should assign sequential triggerIds to all trigger configs', () => {
+      const dataLayers: DataLayer[] = [{ event: 'page_view', paths: [] }];
+
+      const result = service.getTriggers(
+        mockAccountId,
+        mockContainerId,
+        dataLayers
+      );
+
+      for (let i = 0; i < result.length; i++) {
+        expect(result[i].triggerId).toBe(String(i + 1));
+      }
+    });
+
+    it('should propagate accountId and containerId to all trigger configs', () => {
+      const dataLayers: DataLayer[] = [{ event: 'page_view', paths: [] }];
+
+      const result = service.getTriggers(
+        mockAccountId,
+        mockContainerId,
+        dataLayers
+      );
+
+      for (const trigger of result) {
+        expect(trigger.accountId).toBe(mockAccountId);
+        expect(trigger.containerId).toBe(mockContainerId);
+      }
+    });
+
+    it('should handle multiple data layer events with correct trigger count', () => {
+      const dataLayers: DataLayer[] = [
+        { event: 'page_view', paths: [] },
+        { event: 'purchase', paths: [] },
+        { event: 'sign_up', paths: [] }
+      ];
+
+      const result = service.getTriggers(
+        mockAccountId,
+        mockContainerId,
+        dataLayers
+      );
+
+      // Currently only event triggers are produced (3 total).
+      // Scroll/video triggers are disabled due to hardcoded empty data in
+      // ScrollTrigger.createScrollTrigger and VideoTrigger.createVideoTrigger.
+      expect(result).toHaveLength(3);
+    });
+
+    it('should produce trigger configs with customEventFilter for event triggers', () => {
+      const dataLayers: DataLayer[] = [{ event: 'purchase', paths: [] }];
+
+      const result = service.getTriggers(
+        mockAccountId,
+        mockContainerId,
+        dataLayers
+      );
+
+      const eventTrigger = result.find(
+        (t) => t.name === 'event equals purchase'
+      );
+      expect(eventTrigger?.customEventFilter).toBeDefined();
+      expect(eventTrigger?.customEventFilter).toHaveLength(1);
+      expect(eventTrigger?.customEventFilter?.[0].type).toBe('EQUALS');
+    });
+  });
+});

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/trigger-manager.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/trigger-manager.service.ts
@@ -46,11 +46,13 @@ export class TriggerManager {
     );
     const videoTriggers = this.videoTrigger.createVideoTrigger(
       accountId,
-      containerId
+      containerId,
+      dataLayer
     );
     const scrollTriggers = this.scrollTrigger.createScrollTrigger(
       accountId,
-      containerId
+      containerId,
+      dataLayer
     );
     return [...eventTriggers, ...videoTriggers, ...scrollTriggers];
   }

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/variable-manager.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/managers/variable-manager.service.spec.ts
@@ -1,0 +1,221 @@
+import { TestBed } from '@angular/core/testing';
+import { VariableManager } from './variable-manager.service';
+import { DataLayerVariable } from '../variables/data-layer-variable.service';
+import { ScrollVariable } from '../variables/scroll-variable.service';
+import { VideoVariable } from '../variables/video-variable.service';
+import { ConstantVariable } from '../variables/constant-variable.service';
+import { EventSettingsVariableService } from '../variables/event-settings-variable.service';
+import { EventUtils } from '../../utils/event-utils.service';
+import { ParameterUtils } from '../utils/parameter-utils.service';
+import type { DataLayer, EventSettingsVariable, VariableConfig } from '@utils';
+
+describe('VariableManager', () => {
+  let service: VariableManager;
+  let eventUtils: EventUtils;
+
+  const mockAccountId = 'acc-1';
+  const mockContainerId = 'con-1';
+  const mockMeasurementId = 'G-ABCDEFGH';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        VariableManager,
+        DataLayerVariable,
+        ScrollVariable,
+        VideoVariable,
+        ConstantVariable,
+        EventSettingsVariableService,
+        EventUtils,
+        ParameterUtils
+      ]
+    });
+    service = TestBed.inject(VariableManager);
+    eventUtils = TestBed.inject(EventUtils);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getVariables', () => {
+    it('should create data layer variables from provided data layers', () => {
+      const dataLayers: DataLayer[] = [
+        { event: 'page_view', paths: ['page_location', 'page_title'] }
+      ];
+
+      const result = service.getVariables({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        measurementId: mockMeasurementId,
+        dataLayers,
+        esvContent: []
+      });
+
+      // Should include DLV variables for each path + the measurement ID constant
+      const dlvVars = result.filter((v) => v.name.startsWith('DLV - '));
+      expect(dlvVars).toHaveLength(2);
+      expect(dlvVars.map((v) => v.name)).toEqual(
+        expect.arrayContaining(['DLV - page_location', 'DLV - page_title'])
+      );
+    });
+
+    it('should include a measurement ID constant variable', () => {
+      const result = service.getVariables({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        measurementId: mockMeasurementId,
+        dataLayers: [],
+        esvContent: []
+      });
+
+      const constVar = result.find((v) => v.name === 'CONST - Measurement ID');
+      expect(constVar).toBeTruthy();
+      expect(constVar?.type).toBe('c');
+    });
+
+    it('should deduplicate data layer variables by name', () => {
+      const dataLayers: DataLayer[] = [
+        { event: 'page_view', paths: ['page_location'] },
+        { event: 'purchase', paths: ['page_location', 'value'] }
+      ];
+
+      const result = service.getVariables({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        measurementId: mockMeasurementId,
+        dataLayers,
+        esvContent: []
+      });
+
+      const dlvVars = result.filter((v) => v.name.startsWith('DLV - '));
+      // 'page_location' appears in both events but should only be created once
+      expect(dlvVars).toHaveLength(2);
+      const names = dlvVars.map((v) => v.name);
+      expect(names).toEqual(
+        expect.arrayContaining(['DLV - page_location', 'DLV - value'])
+      );
+    });
+
+    it('should assign sequential variableIds starting from "1"', () => {
+      const result = service.getVariables({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        measurementId: mockMeasurementId,
+        dataLayers: [],
+        esvContent: []
+      });
+
+      // At minimum we have the measurement ID constant
+      expect(result.length).toBeGreaterThan(0);
+      for (let i = 0; i < result.length; i++) {
+        expect(result[i].variableId).toBe(String(i + 1));
+      }
+    });
+
+    it('should create event settings variables when esvContent is provided', () => {
+      const esvContent: EventSettingsVariable[] = [
+        {
+          name: 'GA4 Event Settings',
+          parameters: [{ param1: 'value1' }]
+        }
+      ];
+
+      const result = service.getVariables({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        measurementId: mockMeasurementId,
+        dataLayers: [],
+        esvContent
+      });
+
+      const esvVars = result.filter((v) => v.type === 'gtes');
+      expect(esvVars.length).toBeGreaterThan(0);
+    });
+
+    it('should handle empty data layers and esv content', () => {
+      const result = service.getVariables({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        measurementId: mockMeasurementId,
+        dataLayers: [],
+        esvContent: []
+      });
+
+      // Should at least have the constant measurement ID variable
+      expect(result.length).toBeGreaterThan(0);
+      expect(result.every((v) => typeof v.variableId === 'string')).toBe(true);
+    });
+  });
+
+  describe('getBuiltInVariables', () => {
+    it('should return empty array when no video or scroll events exist', () => {
+      const dataLayers: DataLayer[] = [{ event: 'page_view', paths: [] }];
+
+      const result = service.getBuiltInVariables({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        dataLayers
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it('should include video built-in variables when video events are present', () => {
+      const dataLayers: DataLayer[] = [{ event: 'video_start', paths: [] }];
+
+      const result = service.getBuiltInVariables({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        dataLayers
+      });
+
+      const videoVarNames = result.map((v) => v.name);
+      expect(videoVarNames).toEqual(
+        expect.arrayContaining([
+          'Video Provider',
+          'Video URL',
+          'Video Title',
+          'Video Duration',
+          'Video Percent',
+          'Video Visible',
+          'Video Status',
+          'Video Current Time'
+        ])
+      );
+    });
+
+    it('should include scroll built-in variable when scroll event is present', () => {
+      const dataLayers: DataLayer[] = [{ event: 'scroll', paths: [] }];
+
+      const result = service.getBuiltInVariables({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        dataLayers
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('Scroll Depth Threshold');
+    });
+
+    it('should include both video and scroll variables when both event types exist', () => {
+      const dataLayers: DataLayer[] = [
+        { event: 'video_start', paths: [] },
+        { event: 'scroll', paths: [] }
+      ];
+
+      const result = service.getBuiltInVariables({
+        accountId: mockAccountId,
+        containerId: mockContainerId,
+        dataLayers
+      });
+
+      const names = result.map((v) => v.name);
+      expect(names).toEqual(
+        expect.arrayContaining(['Scroll Depth Threshold', 'Video Provider'])
+      );
+      // Video has 8 built-ins, scroll has 1
+      expect(result.length).toBe(9);
+    });
+  });
+});

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/event-tag.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/event-tag.service.ts
@@ -1,16 +1,13 @@
 import { EventTagConfig, Parameter, Tag, TagTypeEnum, Trigger } from '@utils';
 import { Injectable } from '@angular/core';
 import { ParameterUtils } from '../utils/parameter-utils.service';
-import { EcParamsService } from '../../utils/ec-params.service';
+import { CONSENT_STATUS_NOT_NEEDED } from '../utils/constant';
 
 @Injectable({
   providedIn: 'root'
 })
 export class EventTag {
-  constructor(
-    private readonly parameterUtils: ParameterUtils,
-    private readonly ecParamsService: EcParamsService
-  ) {}
+  constructor(private readonly parameterUtils: ParameterUtils) {}
 
   private processEcommerceData(
     tag: Tag,
@@ -45,7 +42,7 @@ export class EventTag {
         type: 'MAP'
       },
       consentSettings: {
-        consentStatus: 'NOT_SET'
+        consentStatus: CONSENT_STATUS_NOT_NEEDED
       }
     };
   }

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/event-tag.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/event-tag.spec.ts
@@ -94,7 +94,7 @@ describe('EventTag', () => {
         type: 'MAP'
       },
       consentSettings: {
-        consentStatus: 'NOT_SET'
+        consentStatus: 'NOT_NEEDED'
       }
     };
 

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/google-tag.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/google-tag.service.ts
@@ -1,6 +1,7 @@
 import { GoogleTagConfig, TagTypeEnum } from '@utils';
 import { Injectable } from '@angular/core';
 import { ParameterUtils } from '../utils/parameter-utils.service';
+import { CONSENT_STATUS_NOT_NEEDED } from '../utils/constant';
 
 @Injectable({
   providedIn: 'root'
@@ -10,7 +11,7 @@ export class GoogleTag {
   private static readonly DEFAULT_TRIGGER_ID = '2147479553';
   private static readonly TAG_FIRING_OPTION = 'ONCE_PER_EVENT';
   private static readonly MONITORING_METADATA_TYPE = 'MAP';
-  private static readonly CONSENT_STATUS = 'NOT_SET';
+  private static readonly CONSENT_STATUS = CONSENT_STATUS_NOT_NEEDED;
   private static readonly MEASUREMENT_ID_TEMPLATE =
     '{{CONST - Measurement ID}}';
 

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/google-tag.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/google-tag.spec.ts
@@ -67,7 +67,7 @@ describe('Google Tag', () => {
         type: 'MAP'
       },
       consentSettings: {
-        consentStatus: 'NOT_SET'
+        consentStatus: 'NOT_NEEDED'
       }
     };
     expect(result).toEqual(expectedTag);

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/scroll-tag.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/scroll-tag.service.ts
@@ -9,7 +9,7 @@ import { CONSENT_STATUS_NOT_NEEDED } from '../utils/constant';
 })
 export class ScrollTag {
   // Constants for easier maintenance
-  private static readonly TRIGGER_NAME = 'event scroll';
+  private static readonly TRIGGER_NAME = 'scroll';
   private static readonly TAG_NAME = 'GA4 event - scroll';
   private static readonly EVENT_NAME = 'scroll';
   private static readonly FINGERPRINT = '1690184079241';

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/scroll-tag.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/scroll-tag.service.ts
@@ -2,6 +2,7 @@ import { EventTagConfig, TagTypeEnum, Trigger, DataLayer } from '@utils';
 import { Injectable } from '@angular/core';
 import { ParameterUtils } from '../utils/parameter-utils.service';
 import { EventUtils } from '../../utils/event-utils.service';
+import { CONSENT_STATUS_NOT_NEEDED } from '../utils/constant';
 
 @Injectable({
   providedIn: 'root'
@@ -59,7 +60,7 @@ export class ScrollTag {
           type: 'MAP'
         },
         consentSettings: {
-          consentStatus: 'NOT_SET'
+          consentStatus: CONSENT_STATUS_NOT_NEEDED
         }
       }
     ];

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/scroll-tag.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/scroll-tag.spec.ts
@@ -180,7 +180,7 @@ describe('ScrollTag', () => {
             type: 'MAP'
           },
           consentSettings: {
-            consentStatus: 'NOT_SET'
+            consentStatus: 'NOT_NEEDED'
           }
         }
       ];

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/scroll-tag.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/scroll-tag.spec.ts
@@ -48,7 +48,7 @@ describe('ScrollTag', () => {
       const configurationName = 'TestConfig';
       const accountId = 'account123';
       const containerId = 'container456';
-      const triggers: Trigger[] = []; // No triggers matching 'event scroll'
+      const triggers: Trigger[] = []; // No triggers matching 'scroll'
 
       vi.spyOn(eventUtils, 'isIncludeScroll').mockReturnValue(true);
       vi.spyOn(console, 'error').mockImplementation(() => undefined); // Mock console.error
@@ -74,7 +74,7 @@ describe('ScrollTag', () => {
       const containerId = 'container456';
       const triggers: Trigger[] = [
         {
-          name: 'event scroll',
+          name: 'scroll',
           triggerId: 'trigger789'
         }
       ];

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/video-tag.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/video-tag.service.ts
@@ -9,14 +9,13 @@ import {
 import { EventUtils } from '../../utils/event-utils.service';
 import { Injectable } from '@angular/core';
 import { ParameterUtils } from '../utils/parameter-utils.service';
-import { CONSENT_STATUS_NOT_NEEDED } from '../utils/constant';
+import { CONSENT_STATUS_NOT_NEEDED, BUILT_IN_VIDEO_EVENTS } from '../utils/constant';
 
 @Injectable({
   providedIn: 'root'
 })
 export class VideoTag {
   // Constants for maintenance
-  private static readonly TRIGGER_NAME = 'event youtube video';
   private static readonly EVENT_TAG_NAME = 'GA4 event - Video';
   private static readonly HTML_TAG_NAME = 'cHTML - Youtube iframe API script';
   private static readonly EVENT_NAME_TEMPLATE = 'video_{{Video Status}}';
@@ -136,7 +135,10 @@ export class VideoTag {
       if (!this.eventUtils.isIncludeVideo(dataLayers)) {
         return [];
       }
-      const trigger = triggers.find((t) => t.name === VideoTag.TRIGGER_NAME);
+      // Match the trigger by data layer event name (e.g. 'video_start')
+      const trigger = triggers.find((t) =>
+        BUILT_IN_VIDEO_EVENTS.includes(t.name)
+      );
       if (!trigger?.triggerId) {
         throw new Error("Couldn't find matching trigger for video tag");
       }

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/video-tag.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/video-tag.service.ts
@@ -9,6 +9,7 @@ import {
 import { EventUtils } from '../../utils/event-utils.service';
 import { Injectable } from '@angular/core';
 import { ParameterUtils } from '../utils/parameter-utils.service';
+import { CONSENT_STATUS_NOT_NEEDED } from '../utils/constant';
 
 @Injectable({
   providedIn: 'root'
@@ -82,7 +83,7 @@ export class VideoTag {
       firingTriggerId: [triggerId],
       tagFiringOption: 'ONCE_PER_EVENT',
       monitoringMetadata: { type: 'MAP' },
-      consentSettings: { consentStatus: 'NOT_SET' }
+      consentSettings: { consentStatus: CONSENT_STATUS_NOT_NEEDED }
     };
   }
 
@@ -112,7 +113,7 @@ export class VideoTag {
       firingTriggerId: [triggerId],
       tagFiringOption: 'ONCE_PER_EVENT',
       monitoringMetadata: { type: 'MAP' },
-      consentSettings: { consentStatus: 'NOT_SET' }
+      consentSettings: { consentStatus: CONSENT_STATUS_NOT_NEEDED }
     };
   }
 

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/video-tag.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/video-tag.service.ts
@@ -9,7 +9,10 @@ import {
 import { EventUtils } from '../../utils/event-utils.service';
 import { Injectable } from '@angular/core';
 import { ParameterUtils } from '../utils/parameter-utils.service';
-import { CONSENT_STATUS_NOT_NEEDED, BUILT_IN_VIDEO_EVENTS } from '../utils/constant';
+import {
+  CONSENT_STATUS_NOT_NEEDED,
+  BUILT_IN_VIDEO_EVENTS
+} from '../utils/constant';
 
 @Injectable({
   providedIn: 'root'

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/video-tag.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/video-tag.spec.ts
@@ -52,7 +52,7 @@ describe('VideoTag', () => {
       const configurationName = 'TestConfig';
       const accountId = 'account123';
       const containerId = 'container456';
-      const triggers: Trigger[] = []; // No triggers matching 'event youtube video'
+      const triggers: Trigger[] = []; // No triggers matching video event names
 
       vi.spyOn(eventUtils, 'isIncludeVideo').mockReturnValue(true);
       vi.spyOn(console, 'error').mockImplementation(() => undefined); // Mock console.error
@@ -78,7 +78,7 @@ describe('VideoTag', () => {
       const containerId = 'container456';
       const triggers: Trigger[] = [
         {
-          name: 'event youtube video',
+          name: 'video_start',
           triggerId: 'trigger789'
         }
       ];

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/video-tag.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/tags/video-tag.spec.ts
@@ -231,7 +231,7 @@ describe('VideoTag', () => {
           type: 'MAP'
         },
         consentSettings: {
-          consentStatus: 'NOT_SET'
+          consentStatus: 'NOT_NEEDED'
         }
       };
 
@@ -255,7 +255,7 @@ describe('VideoTag', () => {
           type: 'MAP'
         },
         consentSettings: {
-          consentStatus: 'NOT_SET'
+          consentStatus: 'NOT_NEEDED'
         }
       };
       expect(result).toEqual([expected, expectedHTMLScriptTag]);

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/transform.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/transform.service.spec.ts
@@ -1,0 +1,272 @@
+import { TestBed } from '@angular/core/testing';
+import { TransformService, ConvertOptions } from './transform.service';
+import { ConfigManager } from './managers/config-manager.service';
+import { TagManager } from './managers/tag-manager.service';
+import { TriggerManager } from './managers/trigger-manager.service';
+import { VariableManager } from './managers/variable-manager.service';
+import { DataLayerUtils } from '../utils/data-layer-utils.service';
+import { UtilsService } from '../utils/utils.service';
+import { EventUtils } from '../utils/event-utils.service';
+import { ParameterUtils } from './utils/parameter-utils.service';
+import { EcParamsService } from '../utils/ec-params.service';
+import { EventTag } from './tags/event-tag.service';
+import { GoogleTag } from './tags/google-tag.service';
+import { ScrollTag } from './tags/scroll-tag.service';
+import { VideoTag } from './tags/video-tag.service';
+import { EventTrigger } from './triggers/event-trigger.service';
+import { VideoTrigger } from './triggers/video-trigger.service';
+import { ScrollTrigger } from './triggers/scroll-trigger.service';
+import { DataLayerVariable } from './variables/data-layer-variable.service';
+import { ScrollVariable } from './variables/scroll-variable.service';
+import { VideoVariable } from './variables/video-variable.service';
+import { ConstantVariable } from './variables/constant-variable.service';
+import { EventSettingsVariableService } from './variables/event-settings-variable.service';
+import type { GTMContainerConfig, StrictDataLayerEvent } from '@utils';
+
+describe('TransformService', () => {
+  let service: TransformService;
+
+  const mockGtmConfig: GTMContainerConfig = {
+    accountId: '123456',
+    containerId: '789012',
+    containerName: 'Test Container',
+    gtmId: 'GTM-TEST01',
+    specs: []
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        TransformService,
+        ConfigManager,
+        TagManager,
+        TriggerManager,
+        VariableManager,
+        DataLayerUtils,
+        UtilsService,
+        EventUtils,
+        ParameterUtils,
+        EcParamsService,
+        EventTag,
+        GoogleTag,
+        ScrollTag,
+        VideoTag,
+        EventTrigger,
+        VideoTrigger,
+        ScrollTrigger,
+        DataLayerVariable,
+        ScrollVariable,
+        VideoVariable,
+        ConstantVariable,
+        EventSettingsVariableService
+      ]
+    });
+    service = TestBed.inject(TransformService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('convert', () => {
+    function buildOptions(
+      overrides: Partial<ConvertOptions> = {}
+    ): ConvertOptions {
+      return {
+        googleTagName: 'Google Tag',
+        measurementId: 'G-ABCDEFGH',
+        gtmConfigGenerator: mockGtmConfig,
+        isSendingEcommerceData: 'false',
+        esvContent: [],
+        ...overrides
+      };
+    }
+
+    it('should produce a valid GTMConfiguration from simple specs', () => {
+      const specs: StrictDataLayerEvent[] = [
+        { event: 'page_view', page_location: '/home' }
+      ];
+
+      const options = buildOptions({
+        gtmConfigGenerator: {
+          ...mockGtmConfig,
+          specs
+        }
+      } as ConvertOptions);
+
+      const result = service.convert(options);
+
+      expect(result.exportFormatVersion).toBe(2);
+      expect(result.exportTime).toBeTruthy();
+      expect(result.containerVersion).toBeDefined();
+    });
+
+    it('should include variables, builtInVariables, triggers, and tags', () => {
+      const specs: StrictDataLayerEvent[] = [
+        { event: 'page_view', page_location: '/home' }
+      ];
+
+      const options = buildOptions({
+        gtmConfigGenerator: {
+          ...mockGtmConfig,
+          specs
+        }
+      } as ConvertOptions);
+
+      const result = service.convert(options);
+
+      expect(result.containerVersion.variable.length).toBeGreaterThan(0);
+      expect(result.containerVersion.tag.length).toBeGreaterThan(0);
+      expect(result.containerVersion.trigger.length).toBeGreaterThan(0);
+    });
+
+    it('should set the correct container name and publicId', () => {
+      const specs: StrictDataLayerEvent[] = [{ event: 'page_view' }];
+
+      const options = buildOptions({
+        gtmConfigGenerator: {
+          ...mockGtmConfig,
+          specs
+        }
+      } as ConvertOptions);
+
+      const result = service.convert(options);
+
+      expect(result.containerVersion.container.name).toBe('Test Container');
+      expect(result.containerVersion.container.publicId).toBe('GTM-TEST01');
+    });
+
+    it('should produce tag configs whose tagIds match their firingTriggerIds linkage', () => {
+      const specs: StrictDataLayerEvent[] = [
+        { event: 'page_view', page_location: '/home' },
+        { event: 'purchase', value: '799', currency: 'TWD' }
+      ];
+
+      const options = buildOptions({
+        gtmConfigGenerator: {
+          ...mockGtmConfig,
+          specs
+        }
+      } as ConvertOptions);
+
+      const result = service.convert(options);
+
+      // Every tag (except the base Google Tag which uses a built-in trigger)
+      // should reference trigger IDs that exist in the trigger array
+      const triggerIds = new Set(
+        result.containerVersion.trigger.map((t) => t.triggerId)
+      );
+
+      for (const tag of result.containerVersion.tag) {
+        if (tag.firingTriggerId) {
+          for (const ftId of tag.firingTriggerId) {
+            // The Google Tag uses the hardcoded '2147479553' trigger
+            if (ftId === '2147479553') continue;
+            expect(triggerIds.has(ftId)).toBe(true);
+          }
+        }
+      }
+    });
+
+    it('should create event triggers matching data layer events', () => {
+      const specs: StrictDataLayerEvent[] = [
+        { event: 'sign_up', method: 'email' }
+      ];
+
+      const options = buildOptions({
+        gtmConfigGenerator: {
+          ...mockGtmConfig,
+          specs
+        }
+      } as ConvertOptions);
+
+      const result = service.convert(options);
+
+      const signUpTrigger = result.containerVersion.trigger.find(
+        (t) => t.name === 'event equals sign_up'
+      );
+      expect(signUpTrigger).toBeTruthy();
+      expect(signUpTrigger?.type).toBe('CUSTOM_EVENT');
+    });
+
+    it('should create data layer variables for each spec path', () => {
+      const specs: StrictDataLayerEvent[] = [
+        {
+          event: 'page_view',
+          page_location: '/home',
+          page_title: 'Home Page'
+        }
+      ];
+
+      const options = buildOptions({
+        gtmConfigGenerator: {
+          ...mockGtmConfig,
+          specs
+        }
+      } as ConvertOptions);
+
+      const result = service.convert(options);
+
+      const variableNames = result.containerVersion.variable.map((v) => v.name);
+      expect(variableNames).toEqual(
+        expect.arrayContaining(['DLV - page_location', 'DLV - page_title'])
+      );
+    });
+
+    it('should include a measurement ID constant variable', () => {
+      const specs: StrictDataLayerEvent[] = [{ event: 'page_view' }];
+
+      const options = buildOptions({
+        gtmConfigGenerator: {
+          ...mockGtmConfig,
+          specs
+        }
+      } as ConvertOptions);
+
+      const result = service.convert(options);
+
+      const constVar = result.containerVersion.variable.find(
+        (v) => v.name === 'CONST - Measurement ID'
+      );
+      expect(constVar).toBeTruthy();
+      expect(constVar?.type).toBe('c');
+    });
+
+    it('should deduplicate data layer variables shared across events', () => {
+      const specs: StrictDataLayerEvent[] = [
+        { event: 'page_view', page_location: '/home' },
+        { event: 'purchase', page_location: '/checkout', value: '799' }
+      ];
+
+      const options = buildOptions({
+        gtmConfigGenerator: {
+          ...mockGtmConfig,
+          specs
+        }
+      } as ConvertOptions);
+
+      const result = service.convert(options);
+
+      const pageLocationVars = result.containerVersion.variable.filter(
+        (v) => v.name === 'DLV - page_location'
+      );
+      expect(pageLocationVars).toHaveLength(1);
+    });
+
+    it('should handle empty specs gracefully', () => {
+      const options = buildOptions({
+        gtmConfigGenerator: {
+          ...mockGtmConfig,
+          specs: []
+        }
+      } as ConvertOptions);
+
+      const result = service.convert(options);
+
+      // Should still produce a valid structure (at least Google Tag + measurement constant)
+      expect(result.exportFormatVersion).toBe(2);
+      expect(result.containerVersion.variable.length).toBeGreaterThan(0);
+      expect(result.containerVersion.tag.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/transform.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/transform.service.spec.ts
@@ -8,7 +8,6 @@ import { DataLayerUtils } from '../utils/data-layer-utils.service';
 import { UtilsService } from '../utils/utils.service';
 import { EventUtils } from '../utils/event-utils.service';
 import { ParameterUtils } from './utils/parameter-utils.service';
-import { EcParamsService } from '../utils/ec-params.service';
 import { EventTag } from './tags/event-tag.service';
 import { GoogleTag } from './tags/google-tag.service';
 import { ScrollTag } from './tags/scroll-tag.service';
@@ -46,7 +45,6 @@ describe('TransformService', () => {
         UtilsService,
         EventUtils,
         ParameterUtils,
-        EcParamsService,
         EventTag,
         GoogleTag,
         ScrollTag,

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/transform.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/transform.service.spec.ts
@@ -266,5 +266,77 @@ describe('TransformService', () => {
       expect(result.containerVersion.variable.length).toBeGreaterThan(0);
       expect(result.containerVersion.tag.length).toBeGreaterThan(0);
     });
+
+    it('should include scroll trigger and tag when specs contain scroll event', () => {
+      const specs: StrictDataLayerEvent[] = [
+        { event: 'page_view', page_location: '/home' },
+        { event: 'scroll' }
+      ];
+
+      const options = buildOptions({
+        gtmConfigGenerator: {
+          ...mockGtmConfig,
+          specs
+        }
+      } as ConvertOptions);
+
+      const result = service.convert(options);
+
+      const triggerNames = result.containerVersion.trigger.map((t) => t.name);
+      expect(triggerNames).toEqual(
+        expect.arrayContaining(['event scroll'])
+      );
+
+      const tagNames = result.containerVersion.tag.map((t) => t.name);
+      expect(tagNames).toEqual(
+        expect.arrayContaining(['GA4 event - scroll'])
+      );
+    });
+
+    it('should include video trigger and tags when specs contain video event', () => {
+      const specs: StrictDataLayerEvent[] = [
+        { event: 'page_view', page_location: '/home' },
+        { event: 'video_start' }
+      ];
+
+      const options = buildOptions({
+        gtmConfigGenerator: {
+          ...mockGtmConfig,
+          specs
+        }
+      } as ConvertOptions);
+
+      const result = service.convert(options);
+
+      const triggerNames = result.containerVersion.trigger.map((t) => t.name);
+      expect(triggerNames).toEqual(
+        expect.arrayContaining(['event youtube video'])
+      );
+
+      const tagNames = result.containerVersion.tag.map((t) => t.name);
+      expect(tagNames).toEqual(
+        expect.arrayContaining(['GA4 event - Video'])
+      );
+    });
+
+    it('should NOT include scroll/video triggers when specs lack those events', () => {
+      const specs: StrictDataLayerEvent[] = [
+        { event: 'page_view', page_location: '/home' }
+      ];
+
+      const options = buildOptions({
+        gtmConfigGenerator: {
+          ...mockGtmConfig,
+          specs
+        }
+      } as ConvertOptions);
+
+      const result = service.convert(options);
+
+      const triggerNames = result.containerVersion.trigger.map((t) => t.name);
+      expect(triggerNames).not.toEqual(
+        expect.arrayContaining(['event scroll', 'event youtube video'])
+      );
+    });
   });
 });

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/transform.service.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/transform.service.spec.ts
@@ -283,14 +283,10 @@ describe('TransformService', () => {
       const result = service.convert(options);
 
       const triggerNames = result.containerVersion.trigger.map((t) => t.name);
-      expect(triggerNames).toEqual(
-        expect.arrayContaining(['event scroll'])
-      );
+      expect(triggerNames).toEqual(expect.arrayContaining(['event scroll']));
 
       const tagNames = result.containerVersion.tag.map((t) => t.name);
-      expect(tagNames).toEqual(
-        expect.arrayContaining(['GA4 event - scroll'])
-      );
+      expect(tagNames).toEqual(expect.arrayContaining(['GA4 event - scroll']));
     });
 
     it('should include video trigger and tags when specs contain video event', () => {
@@ -314,9 +310,7 @@ describe('TransformService', () => {
       );
 
       const tagNames = result.containerVersion.tag.map((t) => t.name);
-      expect(tagNames).toEqual(
-        expect.arrayContaining(['GA4 event - Video'])
-      );
+      expect(tagNames).toEqual(expect.arrayContaining(['GA4 event - Video']));
     });
 
     it('should NOT include scroll/video triggers when specs lack those events', () => {

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/triggers/scroll-trigger.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/triggers/scroll-trigger.service.ts
@@ -2,7 +2,8 @@ import { Injectable } from '@angular/core';
 import {
   ScrollDepthTriggerConfig,
   TriggerConfig,
-  TriggerTypeEnum
+  TriggerTypeEnum,
+  DataLayer
 } from '@utils';
 import { ParameterUtils } from '../utils/parameter-utils.service';
 import { EventUtils } from '../../utils/event-utils.service';
@@ -55,11 +56,13 @@ export class ScrollTrigger {
     };
   }
 
-  createScrollTrigger(accountId: string, containerId: string): TriggerConfig[] {
+  createScrollTrigger(
+    accountId: string,
+    containerId: string,
+    dataLayers: DataLayer[] = []
+  ): TriggerConfig[] {
     try {
-      // TODO: get the data from the UI
-      const data = [] as any;
-      if (this.eventUtils.isIncludeScroll(data)) {
+      if (this.eventUtils.isIncludeScroll(dataLayers)) {
         const _scrollTrigger = this.scrollTriggers({
           accountId,
           containerId

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/triggers/scroll-trigger.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/triggers/scroll-trigger.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { ScrollTrigger } from './scroll-trigger.service';
 import { ParameterUtils } from '../utils/parameter-utils.service';
 import { EventUtils } from '../../utils/event-utils.service';
-import { ScrollDepthTriggerConfig, TriggerTypeEnum } from '@utils';
+import { ScrollDepthTriggerConfig, TriggerTypeEnum, DataLayer } from '@utils';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 describe('scrollTrigger', () => {
@@ -81,5 +81,29 @@ describe('scrollTrigger', () => {
       expect.any(Error)
     );
     consoleSpy.mockRestore();
+  });
+
+  it('should create a scroll trigger when data layers contain scroll event', () => {
+    const dataLayers: DataLayer[] = [{ event: 'scroll', paths: [] }];
+
+    const result = service.createScrollTrigger(
+      'test-account',
+      'test-container',
+      dataLayers
+    );
+
+    expect(result).toEqual([mockScrollTriggerConfig]);
+  });
+
+  it('should return empty array when data layers do NOT contain scroll event', () => {
+    const dataLayers: DataLayer[] = [{ event: 'page_view', paths: [] }];
+
+    const result = service.createScrollTrigger(
+      'test-account',
+      'test-container',
+      dataLayers
+    );
+
+    expect(result).toEqual([]);
   });
 });

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/triggers/video-trigger.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/triggers/video-trigger.service.ts
@@ -1,4 +1,4 @@
-import { TriggerTypeEnum, YouTubeVideoTriggerConfig } from '@utils';
+import { TriggerTypeEnum, YouTubeVideoTriggerConfig, DataLayer } from '@utils';
 import { Injectable } from '@angular/core';
 import { EventUtils } from '../../utils/event-utils.service';
 
@@ -69,14 +69,11 @@ export class VideoTrigger {
 
   createVideoTrigger(
     accountId: string,
-    containerId: string
+    containerId: string,
+    dataLayers: DataLayer[] = []
   ): YouTubeVideoTriggerConfig[] {
-    // TODO: get the information whether the video is included in the data
     try {
-      const data = [] as any;
-      console.log('Creating video trigger...');
-      console.log('data: ', data);
-      if (this.eventUtils.isIncludeVideo(data)) {
+      if (this.eventUtils.isIncludeVideo(dataLayers)) {
         const _videoTrigger = this.videoTrigger({
           accountId,
           containerId

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/triggers/video-trigger.spec.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/triggers/video-trigger.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { VideoTrigger } from './video-trigger.service';
 import { EventUtils } from '../../utils/event-utils.service';
-import { TriggerTypeEnum, YouTubeVideoTriggerConfig } from '@utils';
+import { TriggerTypeEnum, YouTubeVideoTriggerConfig, DataLayer } from '@utils';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 describe('VideoTrigger', () => {
@@ -85,5 +85,29 @@ describe('VideoTrigger', () => {
     );
 
     consoleSpy.mockRestore();
+  });
+
+  it('should create a video trigger when data layers contain video event', () => {
+    const dataLayers: DataLayer[] = [{ event: 'video_start', paths: [] }];
+
+    const result = service.createVideoTrigger(
+      'test-account',
+      'test-container',
+      dataLayers
+    );
+
+    expect(result).toEqual([mockVideoTriggerConfig]);
+  });
+
+  it('should return empty array when data layers do NOT contain video event', () => {
+    const dataLayers: DataLayer[] = [{ event: 'page_view', paths: [] }];
+
+    const result = service.createVideoTrigger(
+      'test-account',
+      'test-container',
+      dataLayers
+    );
+
+    expect(result).toEqual([]);
   });
 });

--- a/libs/data-access/src/lib/services/gtm-json-converter/transform/utils/constant.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/transform/utils/constant.ts
@@ -2,9 +2,12 @@ export const BUILT_IN_SCROLL_EVENT = ['scroll'];
 export const BUILT_IN_VIDEO_EVENTS = [
   'video_start',
   'video_progress',
-  'video_complete',
+  'video_complete'
 ];
 export const BUILT_IN_EVENTS = [
   ...BUILT_IN_SCROLL_EVENT,
-  ...BUILT_IN_VIDEO_EVENTS,
+  ...BUILT_IN_VIDEO_EVENTS
 ];
+
+/** Default consent status applied to all GTM tags in exported containers. */
+export const CONSENT_STATUS_NOT_NEEDED = 'NOT_NEEDED';

--- a/libs/data-access/src/lib/services/gtm-json-converter/utils/ec-params.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/utils/ec-params.service.ts
@@ -1,48 +1,43 @@
-import { Injectable } from '@angular/core';
-
-@Injectable({
-  providedIn: 'root'
-})
-export class EcParamsService {
-  getEcParams() {
-    return [
-      'value',
-      'currency',
-      'transaction_id',
-      'coupon',
-      'shipping',
-      'tax',
-      'shipping_tier',
-      'payment_type',
-      'items',
-      'promotion_id',
-      'promotion_name',
-      'creative_name',
-      'creative_slot',
-      'location_id',
-      'campaign_id',
-      'campaign_name',
-      'source',
-      'medium',
-      'content',
-      'term',
-      'affiliation',
-      'item_list_id',
-      'item_list_name',
-      'search_term',
-      'success',
-      'content_type',
-      'content_id',
-      'content_group',
-      'engagement_time_msec',
-      'form_id',
-      'form_name',
-      'form_destination',
-      'language',
-      'page_location',
-      'page_referrer',
-      'page_title',
-      'screen_resolution'
-    ];
-  }
-}
+/**
+ * Known GA4 ecommerce parameter names.
+ * Used as a reference for filtering/validating ecommerce event data.
+ */
+export const EC_PARAMS = [
+  'value',
+  'currency',
+  'transaction_id',
+  'coupon',
+  'shipping',
+  'tax',
+  'shipping_tier',
+  'payment_type',
+  'items',
+  'promotion_id',
+  'promotion_name',
+  'creative_name',
+  'creative_slot',
+  'location_id',
+  'campaign_id',
+  'campaign_name',
+  'source',
+  'medium',
+  'content',
+  'term',
+  'affiliation',
+  'item_list_id',
+  'item_list_name',
+  'search_term',
+  'success',
+  'content_type',
+  'content_id',
+  'content_group',
+  'engagement_time_msec',
+  'form_id',
+  'form_name',
+  'form_destination',
+  'language',
+  'page_location',
+  'page_referrer',
+  'page_title',
+  'screen_resolution'
+] as const;

--- a/libs/data-access/src/lib/services/gtm-json-converter/utils/utils.service.ts
+++ b/libs/data-access/src/lib/services/gtm-json-converter/utils/utils.service.ts
@@ -21,27 +21,13 @@ export class UtilsService {
   }
 
   outputTime() {
-    //output the time like the format: 2023-08-03 02:16:33
-    const date: Date = new Date();
-
-    const year: number = date.getFullYear();
-
-    let month: number | string = date.getMonth() + 1; // getMonth() is zero-indexed, so we need to add 1
-    month = month < 10 ? '0' + month : month; // ensure month is 2-digits
-
-    let day: number | string = date.getDate();
-    day = day < 10 ? '0' + day : day; // ensure day is 2-digits
-
-    let hours: number | string = date.getHours();
-    hours = hours < 10 ? '0' + hours : hours; // ensure hours is 2-digits
-
-    let minutes: number | string = date.getMinutes();
-    minutes = minutes < 10 ? '0' + minutes : minutes; // ensure minutes is 2-digits
-
-    let seconds: number | string = date.getSeconds();
-    seconds = seconds < 10 ? '0' + seconds : seconds; // ensure seconds is 2-digits
-
-    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+    // output the time in GTM export format: 2023-08-03 02:16:33
+    const d = new Date();
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return (
+      `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+      ` ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+    );
   }
 
   /**

--- a/libs/data-access/src/lib/services/tag-build-mode/tag-build-mode.service.ts
+++ b/libs/data-access/src/lib/services/tag-build-mode/tag-build-mode.service.ts
@@ -1,4 +1,4 @@
-import { computed, Injectable, signal, WritableSignal } from '@angular/core';
+import { Injectable, signal, WritableSignal } from '@angular/core';
 
 /**
  * Semantic enum for the tag-build page mode.
@@ -16,12 +16,9 @@ export class TagBuildModeService {
     TagBuildMode.TagBuild
   );
 
-  // Store the computed signal as a class property
-  private readonly _computedMode = computed(() => this._mode());
-
   // Read the current mode value
   get mode(): TagBuildMode {
-    return this._computedMode();
+    return this._mode();
   }
 
   // Set the current mode

--- a/libs/data-access/src/lib/services/web-worker/web-worker.service.ts
+++ b/libs/data-access/src/lib/services/web-worker/web-worker.service.ts
@@ -1,18 +1,33 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
-export class WebWorkerService {
-  private readonly worker: Worker | undefined;
+export class WebWorkerService implements OnDestroy {
+  private worker: Worker | null = null;
   private readonly subject = new Subject<any>();
+
+  /**
+   * Initialize the worker with a given script URL.
+   * Must be called before postMessage().
+   */
+  init(workerScript: string | URL): void {
+    if (this.worker) {
+      this.terminate();
+    }
+    this.worker = new Worker(workerScript);
+    this.worker.onmessage = ({ data }) => this.subject.next(data);
+    this.worker.onerror = (err) => {
+      console.error('[WebWorkerService] Worker error:', err);
+    };
+  }
 
   // To send data to worker
   postMessage(command: string, data: any): void {
     if (!this.worker) {
-      throw new Error('Worker not initialized');
+      throw new Error('Worker not initialized. Call init(workerScript) first.');
     }
     this.worker.postMessage({ cmd: command, ...data });
   }
@@ -26,6 +41,12 @@ export class WebWorkerService {
   terminate(): void {
     if (this.worker) {
       this.worker.terminate();
+      this.worker = null;
     }
+  }
+
+  ngOnDestroy(): void {
+    this.terminate();
+    this.subject.complete();
   }
 }


### PR DESCRIPTION
## Summary

6-phase progressive refactoring of `ng-tag-build` GTM JSON pipeline.

### Phase 1: Manager-level integration tests (78d9c19a)
- Added 5 orchestrator-layer spec files: TransformService, ConfigManager, TagManager, TriggerManager, VariableManager
- 149→167 tests total

### Phase 2–6: Anti-pattern fixes, cleanup, constants, consent (1e39209a, 3075c018)
- **P2**: Removed redundant `computed()` in TagBuildModeService; fixed module-level `localStorage` read in app.config.ts → `useFactory`
- **P3**: Simplified `outputTime()` with `padStart()`; extracted 7 magic values to named constants in ConfigManager
- **P4**: Converted dead EcParamsService → `EC_PARAMS` constant; deduplicated event name checks in EditorFacadeService; added `init(workerScript)` to WebWorkerService with proper lifecycle
- **P5**: Added 9 edge-case tests for `fixJsonString()` JSON repair (nested objects, booleans, nulls, numbers, comments, etc.)
- **P6**: Changed all `consentStatus` from `NOT_SET` → `NOT_NEEDED` with shared constant (matches GTM-TQXTJ3LC_workspace5.json reference format)

### Critical Bug Fixes (394d6737)
- **ScrollTrigger/VideTrigger**: `createScrollTrigger`/`createVideoTrigger` were hardcoded to `const data = []` — scroll/video triggers NEVER produced. Fixed by accepting `dataLayers` parameter.
- **TriggerManager/TagManager**: Now passes `dataLayer`/`dataLayers` to scroll/video trigger and tag methods.
- **ScrollTag.TRIGGER_NAME**: Changed from `'event scroll'` → `'scroll'` to match simple trigger lookup.
- **VideoTag**: Replaced hardcoded `TRIGGER_NAME` lookup with `BUILT_IN_VIDEO_EVENTS` search.

### Test Results
```
Test Files  25 passed (25)
Tests      167 passed (167)
```