### PR TITLE
fix desktop release flow on main merge

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,17 +2,13 @@ name: Desktop Release
 
 on:
   push:
-    tags:
-      - 'v*.*.*'
+    branches:
+      - main
   workflow_dispatch:
     inputs:
-      release_tag:
-        description: Stable release tag to publish, for example v2.0.0
-        required: true
-        type: string
       checkout_ref:
-        description: Branch, tag, or commit to check out before validating the requested release tag
-        required: true
+        description: Branch, tag, or commit to check out before evaluating the desktop release
+        required: false
         type: string
 
 permissions:
@@ -24,49 +20,190 @@ jobs:
     outputs:
       checkout_ref: ${{ steps.release_context.outputs.checkout_ref }}
       release_tag: ${{ steps.release_context.outputs.release_tag }}
+      release_version: ${{ steps.release_context.outputs.release_version }}
+      should_release: ${{ steps.release_gate.outputs.should_release }}
+      skip_reason: ${{ steps.release_gate.outputs.skip_reason }}
     steps:
-      - name: Resolve requested release
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'push' && github.sha || inputs.checkout_ref || github.sha }}
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+          cache: 'pnpm'
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.0.8 --activate
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Describe release context
         id: release_context
         run: |
+          node tools/scripts/tauri/release/release.ts describe
           node --input-type=module -e "
-          const eventName = process.env.GITHUB_EVENT_NAME;
-          const pushTag = process.env.GITHUB_REF_NAME?.trim() ?? '';
-          const dispatchTag = process.env.INPUT_RELEASE_TAG?.trim() ?? '';
-          const dispatchRef = process.env.INPUT_CHECKOUT_REF?.trim() ?? '';
-          const stableTagPattern = /^v\d+\.\d+\.\d+$/;
-
-          const releaseTag = eventName === 'push' ? pushTag : dispatchTag;
-          const checkoutRef = eventName === 'push' ? pushTag : dispatchRef;
-
-          if (!stableTagPattern.test(releaseTag)) {
-            throw new Error(\`Expected a stable release tag like v2.0.0, received \"\${releaseTag}\".\`);
-          }
-
-          if (!checkoutRef) {
-            throw new Error('A checkout ref is required for desktop releases.');
-          }
+          import { appendFile } from 'node:fs/promises';
+          import { execFileSync } from 'node:child_process';
 
           const outputPath = process.env.GITHUB_OUTPUT;
           if (!outputPath) {
             throw new Error('GITHUB_OUTPUT is not available.');
           }
 
-          await import('node:fs/promises').then(({ appendFile }) =>
-            appendFile(
-              outputPath,
-              \`release_tag=\${releaseTag}\ncheckout_ref=\${checkoutRef}\n\`,
-              'utf8'
-            )
+          const checkoutRef = execFileSync('git', ['rev-parse', 'HEAD'], {
+            encoding: 'utf8'
+          }).trim();
+
+          await appendFile(outputPath, \`checkout_ref=\${checkoutRef}\n\`, 'utf8');
+          console.log(JSON.stringify({ checkoutRef }, null, 2));
+          "
+      - name: Validate release notes exist
+        run: |
+          node --input-type=module -e "
+          import { existsSync } from 'node:fs';
+          import { join } from 'node:path';
+
+          const releaseVersion = process.env.RELEASE_VERSION;
+          if (!releaseVersion) {
+            throw new Error('RELEASE_VERSION is required.');
+          }
+
+          const notesPath = join(
+            process.cwd(),
+            'docs',
+            'releases',
+            \`\${releaseVersion}.md\`
           );
 
-          console.log(JSON.stringify({ releaseTag, checkoutRef }, null, 2));
+          if (!existsSync(notesPath)) {
+            throw new Error(\`Missing \${notesPath}.\`);
+          }
+
+          console.log(\`Verified release notes at \${notesPath}.\`);
           "
         env:
-          INPUT_CHECKOUT_REF: ${{ inputs.checkout_ref }}
-          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_VERSION: ${{ steps.release_context.outputs.release_version }}
+      - name: Resolve release gate
+        id: release_gate
+        uses: actions/github-script@v7
+        env:
+          CHECKOUT_REF: ${{ steps.release_context.outputs.checkout_ref }}
+          RELEASE_TAG: ${{ steps.release_context.outputs.release_tag }}
+          RELEASE_VERSION: ${{ steps.release_context.outputs.release_version }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const checkoutRef = process.env.CHECKOUT_REF?.trim();
+            const releaseTag = process.env.RELEASE_TAG?.trim();
+            const releaseVersion = process.env.RELEASE_VERSION?.trim();
+
+            if (!checkoutRef || !releaseTag || !releaseVersion) {
+              throw new Error('CHECKOUT_REF, RELEASE_TAG, and RELEASE_VERSION are required.');
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const legacyTag = releaseVersion;
+
+            const getReleaseByTag = async (tag) => {
+              try {
+                return await github.rest.repos.getReleaseByTag({
+                  owner,
+                  repo,
+                  tag
+                });
+              } catch (error) {
+                if (error.status === 404) {
+                  return null;
+                }
+
+                throw error;
+              }
+            };
+
+            const getTagSha = async (tag) => {
+              try {
+                const response = await github.rest.git.getRef({
+                  owner,
+                  repo,
+                  ref: `tags/${tag}`
+                });
+
+                if (response.data.object.type === 'tag') {
+                  const annotatedTag = await github.rest.git.getTag({
+                    owner,
+                    repo,
+                    tag_sha: response.data.object.sha
+                  });
+
+                  return annotatedTag.data.object.sha;
+                }
+
+                return response.data.object.sha;
+              } catch (error) {
+                if (error.status === 404) {
+                  return null;
+                }
+
+                throw error;
+              }
+            };
+
+            const releaseCandidates = [
+              { kind: 'release', tag: releaseTag, value: await getReleaseByTag(releaseTag) },
+              { kind: 'release', tag: legacyTag, value: await getReleaseByTag(legacyTag) }
+            ].filter((candidate) => candidate.value);
+
+            if (releaseCandidates.length > 0) {
+              const existing = releaseCandidates[0];
+              const skipReason = `Release already exists for ${existing.tag}; skipping duplicate draft creation.`;
+              core.setOutput('should_release', 'false');
+              core.setOutput('skip_reason', skipReason);
+              core.notice(skipReason);
+              return;
+            }
+
+            const canonicalTagSha = await getTagSha(releaseTag);
+            const legacyTagSha = await getTagSha(legacyTag);
+
+            for (const [tag, sha] of [
+              [releaseTag, canonicalTagSha],
+              [legacyTag, legacyTagSha]
+            ]) {
+              if (sha && sha !== checkoutRef) {
+                throw new Error(
+                  `Existing tag ${tag} points to ${sha}, expected ${checkoutRef}.`
+                );
+              }
+            }
+
+            if (!canonicalTagSha) {
+              await github.rest.git.createRef({
+                owner,
+                repo,
+                ref: `refs/tags/${releaseTag}`,
+                sha: checkoutRef
+              });
+              core.notice(`Created ${releaseTag} at ${checkoutRef}.`);
+            } else {
+              core.notice(`Reusing existing ${releaseTag} at ${checkoutRef}.`);
+            }
+
+            if (legacyTagSha) {
+              core.notice(`Legacy tag ${legacyTag} already exists at ${checkoutRef}.`);
+            }
+
+            core.setOutput('should_release', 'true');
+            core.setOutput('skip_reason', '');
+      - name: Report skipped release
+        if: ${{ steps.release_gate.outputs.should_release != 'true' }}
+        run: echo "${{ steps.release_gate.outputs.skip_reason }}"
 
   build-desktop:
     needs: prepare-release
+    if: ${{ needs.prepare-release.outputs.should_release == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -91,33 +228,6 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'pnpm'
-      - name: Verify checked-out ref matches release tag
-        run: |
-          node --input-type=module -e "
-          import { execFileSync } from 'node:child_process';
-
-          const releaseTag = process.env.RELEASE_TAG;
-          if (!releaseTag) {
-            throw new Error('RELEASE_TAG is required.');
-          }
-
-          const headCommit = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
-          const tagCommit = execFileSync('git', ['rev-list', '-n', '1', releaseTag], { encoding: 'utf8' }).trim();
-
-          if (!tagCommit) {
-            throw new Error(\`Unable to resolve release tag \${releaseTag}.\`);
-          }
-
-          if (headCommit !== tagCommit) {
-            throw new Error(
-              \`Checked-out HEAD \${headCommit} does not match \${releaseTag} commit \${tagCommit}.\`
-            );
-          }
-
-          console.log(\`Verified \${releaseTag} at \${headCommit}.\`);
-          "
-        env:
-          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
         run: |
@@ -175,7 +285,7 @@ jobs:
     needs:
       - prepare-release
       - build-desktop
-    if: ${{ success() }}
+    if: ${{ needs.prepare-release.outputs.should_release == 'true' && success() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -187,33 +297,6 @@ jobs:
         with:
           node-version: '24.x'
           cache: 'pnpm'
-      - name: Verify checked-out ref matches release tag
-        run: |
-          node --input-type=module -e "
-          import { execFileSync } from 'node:child_process';
-
-          const releaseTag = process.env.RELEASE_TAG;
-          if (!releaseTag) {
-            throw new Error('RELEASE_TAG is required.');
-          }
-
-          const headCommit = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
-          const tagCommit = execFileSync('git', ['rev-list', '-n', '1', releaseTag], { encoding: 'utf8' }).trim();
-
-          if (!tagCommit) {
-            throw new Error(\`Unable to resolve release tag \${releaseTag}.\`);
-          }
-
-          if (headCommit !== tagCommit) {
-            throw new Error(
-              \`Checked-out HEAD \${headCommit} does not match \${releaseTag} commit \${tagCommit}.\`
-            );
-          }
-
-          console.log(\`Verified \${releaseTag} at \${headCommit}.\`);
-          "
-        env:
-          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
       - name: Setup pnpm
         run: |
           corepack enable
@@ -223,25 +306,6 @@ jobs:
       - name: Describe release context
         id: release_context
         run: node tools/scripts/tauri/release/release.ts describe --release-tag ${{ needs.prepare-release.outputs.release_tag }}
-      - name: Validate release notes exist
-        run: |
-          node --input-type=module -e "
-          import { existsSync } from 'node:fs';
-          import { join } from 'node:path';
-
-          const notesPath = join(
-            process.cwd(),
-            'docs',
-            'releases',
-            '${{ steps.release_context.outputs.release_version }}.md'
-          );
-
-          if (!existsSync(notesPath)) {
-            throw new Error(\`Missing \${notesPath}.\`);
-          }
-
-          console.log(\`Verified release notes at \${notesPath}.\`);
-          "
       - name: Download desktop release artifacts
         uses: actions/download-artifact@v4
         with:

--- a/tools/scripts/tauri/release/release.spec.ts
+++ b/tools/scripts/tauri/release/release.spec.ts
@@ -14,6 +14,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   assembleReleaseAssets,
   assertVersionAuthoritiesInSync,
+  buildStableReleaseTag,
   buildArtifactName,
   buildAssetFileName,
   createChecksumFileContents,
@@ -144,6 +145,11 @@ describe('release helper', () => {
     expect(() => parseStableReleaseTag('v2.0.0-alpha')).toThrow(
       /stable release tag/
     );
+  });
+
+  it('builds canonical stable release tags from plain versions', () => {
+    expect(buildStableReleaseTag('2.0.0')).toBe('v2.0.0');
+    expect(() => buildStableReleaseTag('v2.0.0')).toThrow(/stable version/);
   });
 
   it('resolves canonical desktop artifact names', () => {
@@ -310,10 +316,17 @@ describe('release helper', () => {
       'utf8'
     );
 
-    expect(workflow).toContain("      - 'v*.*.*'");
+    expect(workflow).toContain('  push:');
+    expect(workflow).toContain('    branches:');
+    expect(workflow).toContain('      - main');
     expect(workflow).toContain('workflow_dispatch:');
-    expect(workflow).toContain('release_tag:');
     expect(workflow).toContain('checkout_ref:');
+    expect(workflow).toContain('should_release:');
+    expect(workflow).toContain('skip_reason:');
+    expect(workflow).toContain('const notesPath = join(');
+    expect(workflow).toContain("docs',");
+    expect(workflow).toContain("releases',");
+    expect(workflow).toContain('Missing \\${notesPath}.');
     expect(workflow).toContain('fail-fast: false');
     expect(workflow).toContain('platform: windows');
     expect(workflow).toContain('platform: macos');
@@ -325,11 +338,21 @@ describe('release helper', () => {
       /publish-release:\s+needs:\s+- prepare-release\s+- build-desktop/su
     );
     expect(workflow).toContain(
+      "if: ${{ needs.prepare-release.outputs.should_release == 'true' }}"
+    );
+    expect(workflow).toContain(
       'pattern: tag-check-desktop-v${{ steps.release_context.outputs.release_version }}-*'
     );
     expect(workflow).toContain(
       'node tools/scripts/tauri/release/release.ts assemble --release-tag ${{ needs.prepare-release.outputs.release_tag }} --artifacts-root dist/downloaded-release-assets --output-dir dist/publish-release'
     );
+    expect(workflow).toContain(
+      'Release already exists for ${existing.tag}; skipping duplicate draft creation.'
+    );
+    expect(workflow).toContain(
+      'Existing tag ${tag} points to ${sha}, expected ${checkoutRef}.'
+    );
+    expect(workflow).toContain('ref: `refs/tags/${releaseTag}`');
     expect(workflow).toContain('Validate checksum manifest');
     expect(workflow).toContain('uses: softprops/action-gh-release@v2');
     expect(workflow).toContain('draft: true');

--- a/tools/scripts/tauri/release/release.ts
+++ b/tools/scripts/tauri/release/release.ts
@@ -188,6 +188,22 @@ export function parseStableReleaseTag(releaseTag: string) {
   return match.groups.version;
 }
 
+export function parseStableVersion(version: string) {
+  const normalizedVersion = version.trim();
+
+  if (!/^\d+\.\d+\.\d+$/.test(normalizedVersion)) {
+    throw new Error(
+      `Expected a stable version like 2.0.0, received "${version}".`
+    );
+  }
+
+  return normalizedVersion;
+}
+
+export function buildStableReleaseTag(version: string) {
+  return `v${parseStableVersion(version)}`;
+}
+
 export function assertVersionAuthoritiesInSync(expectedVersion?: string) {
   const authorities = readVersionAuthorities();
   const discoveredVersions = new Set(Object.values(authorities));
@@ -534,11 +550,12 @@ export async function assembleReleaseAssets(
 
 async function describeRelease(args: string[]) {
   const platformInput = getArgumentValue('--platform', args);
-  const releaseTag = getArgumentValue('--release-tag', args);
-  const expectedVersion = releaseTag
-    ? parseStableReleaseTag(releaseTag)
+  const requestedReleaseTag = getArgumentValue('--release-tag', args);
+  const expectedVersion = requestedReleaseTag
+    ? parseStableReleaseTag(requestedReleaseTag)
     : undefined;
   const version = assertVersionAuthoritiesInSync(expectedVersion);
+  const releaseTag = buildStableReleaseTag(version);
   const platform = platformInput
     ? resolveReleasePlatform(platformInput)
     : undefined;
@@ -546,7 +563,7 @@ async function describeRelease(args: string[]) {
     assetFileName: platform ? buildAssetFileName(version, platform) : '',
     artifactName: platform ? buildArtifactName(version, platform) : '',
     platform: platform ?? '',
-    releaseTag: releaseTag ?? '',
+    releaseTag,
     version
   };
 


### PR DESCRIPTION
## Summary
This changes the desktop release flow so merging into `main` can automatically prepare a draft GitHub release instead of requiring a stable tag push first.

The workflow now derives the release version from the checked-out repository state, keeps the internal version authorities on plain semver like `2.0.0`, and canonicalizes the external GitHub release tag as `v2.0.0`. It validates that `docs/releases/<version>.md` exists before proceeding, skips duplicate draft creation when a release already exists for the version, and fails fast if an existing canonical or legacy tag points at a different commit. When the repository is in a releasable state, it creates or reuses the canonical `v<version>` tag on the checked-out SHA, builds the desktop artifacts, and publishes the draft release from the generated payload.

The release helper and its tests were updated to keep this contract aligned. `release.ts` now centralizes stable version parsing and canonical tag construction, while the release spec covers the `version -> v<version>` mapping and the new workflow gates around release notes, duplicate releases, and tag mismatch protection.

## Validation
I verified the release helper directly with `node tools/scripts/tauri/release/release.ts describe`, which returned `version: 2.0.0` and `releaseTag: v2.0.0`. I also ran `pnpm vitest run tools/scripts/tauri/release/release.spec.ts`, which passed all 11 tests. The repo review checkpoints were rerun as part of this change, and both test review and implementation review passed with non-blocking follow-up suggestions only.
