### PR TITLE
fix: restore release workflow pnpm setup order

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24.x'
-          cache: 'pnpm'
       - name: Setup pnpm
         run: |
           corepack enable
@@ -227,7 +226,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24.x'
-          cache: 'pnpm'
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
         run: |
@@ -296,7 +294,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24.x'
-          cache: 'pnpm'
       - name: Setup pnpm
         run: |
           corepack enable


### PR DESCRIPTION
## Summary
- remove premature pnpm cache setup from the desktop release workflow
- let Corepack provision pnpm before any pnpm-dependent install step runs
- keep the existing release trigger and release policy unchanged

## Verification
- inspected the failing GitHub Actions run and confirmed the error was `Unable to locate executable file: pnpm`
- ran `pnpm review:implementation`
- confirmed the diff only removes the three `cache: ''pnpm''` lines from `.github/workflows/release.yaml`
