### PR TITLE
fix release build spec typing regressions

### DIFF
--- a/libs/utils/src/lib/dtos/report-details.dto.spec.ts
+++ b/libs/utils/src/lib/dtos/report-details.dto.spec.ts
@@ -18,7 +18,6 @@ describe('ReportDetailsDto', () => {
 
   it('overrides defaults with values from the partial payload via Object.assign', () => {
     const dto = new ReportDetailsDto({
-      position: 7,
       eventId: 'evt-1',
       testName: 't',
       eventName: 'page_view',
@@ -26,8 +25,9 @@ describe('ReportDetailsDto', () => {
       requestPassed: true,
       message: 'ok'
     });
-    expect(dto.position).toBe(7);
+    expect(dto.position).toBe(0);
     expect(dto.eventId).toBe('evt-1');
+    expect(dto.testName).toBe('t');
     expect(dto.eventName).toBe('page_view');
     expect(dto.passed).toBe(true);
     expect(dto.requestPassed).toBe(true);

--- a/libs/utils/src/lib/functions/tag-build-contract.spec.ts
+++ b/libs/utils/src/lib/functions/tag-build-contract.spec.ts
@@ -119,7 +119,7 @@ describe('isParameter', () => {
     [undefined, 'undefined'],
     ['string', 'string'],
     [42, 'number']
-  ])('rejects non-records (%s)', (input) => {
+  ])('rejects non-records (%s)', (input, _label) => {
     expect(isParameter(input)).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- fix ReportDetailsDto spec to match the current constructor payload type
- fix tag-build-contract spec callback typing so nest-backend can compile during release
- unblock the Desktop Release workflow on main after prepare-release

## Verification
- pnpm vitest run libs/utils/src/lib/dtos/report-details.dto.spec.ts libs/utils/src/lib/functions/tag-build-contract.spec.ts
- pnpm nx build nest-backend
- pnpm review:test --context-file %TEMP%\\tag-check-release-fix-test-review.txt