### PR TITLE
fix duplicate release gate failure on main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -167,15 +167,20 @@ jobs:
             const canonicalTagSha = await getTagSha(releaseTag);
             const legacyTagSha = await getTagSha(legacyTag);
 
-            for (const [tag, sha] of [
-              [releaseTag, canonicalTagSha],
-              [legacyTag, legacyTagSha]
-            ]) {
-              if (sha && sha !== checkoutRef) {
-                throw new Error(
-                  `Existing tag ${tag} points to ${sha}, expected ${checkoutRef}.`
-                );
-              }
+            if (canonicalTagSha && canonicalTagSha !== checkoutRef) {
+              const skipReason = `Release tag ${releaseTag} already exists at ${canonicalTagSha}; skipping duplicate release for version ${releaseVersion}.`;
+              core.setOutput('should_release', 'false');
+              core.setOutput('skip_reason', skipReason);
+              core.notice(skipReason);
+              return;
+            }
+
+            if (legacyTagSha && legacyTagSha !== checkoutRef) {
+              const skipReason = `Legacy release tag ${legacyTag} already exists at ${legacyTagSha}; skipping duplicate release for version ${releaseVersion}.`;
+              core.setOutput('should_release', 'false');
+              core.setOutput('skip_reason', skipReason);
+              core.notice(skipReason);
+              return;
             }
 
             if (!canonicalTagSha) {


### PR DESCRIPTION
## Summary
- skip duplicate desktop release attempts when the version tag already exists on an older commit
- keep main-merge release flow green instead of failing on an already published version tag
- preserve existing behavior for creating or reusing the canonical release tag on the current commit

## Verification
- pnpm review:plan
- pnpm review:implementation
- pnpm review:status
