### PR TITLE
fix: build release from main trigger commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: desktop-release
+  cancel-in-progress: false
+
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
@@ -105,7 +109,8 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const legacyTag = releaseVersion;
-            let effectiveCheckoutRef = checkoutRef;
+            const tagRefPath = (tag) => `tags/${tag}`;
+            const fullTagRef = (tag) => `refs/${tagRefPath(tag)}`;
 
             const getReleaseByTag = async (tag) => {
               try {
@@ -128,7 +133,7 @@ jobs:
                 const response = await github.rest.git.getRef({
                   owner,
                   repo,
-                  ref: `tags/${tag}`
+                  ref: tagRefPath(tag)
                 });
 
                 if (response.data.object.type === 'tag') {
@@ -168,36 +173,36 @@ jobs:
             const canonicalTagSha = await getTagSha(releaseTag);
             const legacyTagSha = await getTagSha(legacyTag);
 
-            if (canonicalTagSha) {
-              effectiveCheckoutRef = canonicalTagSha;
-              core.notice(`Reusing existing ${releaseTag} at ${canonicalTagSha}.`);
-            } else if (legacyTagSha) {
-              effectiveCheckoutRef = legacyTagSha;
-              await github.rest.git.createRef({
+            if (canonicalTagSha === checkoutRef) {
+              core.notice(`Reusing existing ${releaseTag} at ${checkoutRef}.`);
+            } else if (canonicalTagSha) {
+              await github.rest.git.updateRef({
                 owner,
                 repo,
-                ref: `refs/tags/${releaseTag}`,
-                sha: legacyTagSha
+                ref: tagRefPath(releaseTag),
+                sha: checkoutRef,
+                force: true
               });
-              core.notice(
-                `Created canonical tag ${releaseTag} from legacy tag ${legacyTag} at ${legacyTagSha}.`
+              core.warning(
+                `Updated unreleased tag ${releaseTag} from ${canonicalTagSha} to ${checkoutRef} so the draft release builds the workflow trigger commit. If you fetched the old tag locally, run git fetch --tags --force.`
               );
             } else {
               await github.rest.git.createRef({
                 owner,
                 repo,
-                ref: `refs/tags/${releaseTag}`,
+                ref: fullTagRef(releaseTag),
                 sha: checkoutRef
               });
-              effectiveCheckoutRef = checkoutRef;
-              core.notice(`Created ${releaseTag} at ${checkoutRef}.`);
+              core.notice(`Created canonical tag ${releaseTag} at ${checkoutRef}.`);
             }
 
             if (legacyTagSha) {
-              core.notice(`Legacy tag ${legacyTag} already exists at ${legacyTagSha}.`);
+              core.notice(
+                `Legacy tag ${legacyTag} already exists at ${legacyTagSha}; leaving it unchanged.`
+              );
             }
 
-            core.setOutput('checkout_ref', effectiveCheckoutRef);
+            core.setOutput('checkout_ref', checkoutRef);
             core.setOutput('should_release', 'true');
             core.setOutput('skip_reason', '');
       - name: Report skipped release

--- a/tools/scripts/tauri/release/release.spec.ts
+++ b/tools/scripts/tauri/release/release.spec.ts
@@ -320,6 +320,9 @@ describe('release helper', () => {
     expect(workflow).toContain('    branches:');
     expect(workflow).toContain('      - main');
     expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).toContain('concurrency:');
+    expect(workflow).toContain('group: desktop-release');
+    expect(workflow).toContain('cancel-in-progress: false');
     expect(workflow).toContain('checkout_ref:');
     expect(workflow).toContain('should_release:');
     expect(workflow).toContain('skip_reason:');
@@ -349,20 +352,29 @@ describe('release helper', () => {
     expect(workflow).toContain(
       'Release already exists for ${existing.tag}; skipping duplicate draft creation.'
     );
-    expect(workflow).toContain('let effectiveCheckoutRef = checkoutRef;');
+    expect(workflow).not.toContain('let effectiveCheckoutRef = checkoutRef;');
+    expect(workflow).toContain("core.setOutput('checkout_ref', checkoutRef);");
+    expect(workflow).toContain('const tagRefPath = (tag) => `tags/${tag}`;');
     expect(workflow).toContain(
-      "core.setOutput('checkout_ref', effectiveCheckoutRef);"
+      'const fullTagRef = (tag) => `refs/${tagRefPath(tag)}`;'
     );
     expect(workflow).toContain(
-      'Reusing existing ${releaseTag} at ${canonicalTagSha}.'
+      'Reusing existing ${releaseTag} at ${checkoutRef}.'
     );
     expect(workflow).toContain(
-      'Created canonical tag ${releaseTag} from legacy tag ${legacyTag} at ${legacyTagSha}.'
+      'Updated unreleased tag ${releaseTag} from ${canonicalTagSha} to ${checkoutRef}'
+    );
+    expect(workflow).toContain('github.rest.git.updateRef({');
+    expect(workflow).toContain('ref: tagRefPath(releaseTag)');
+    expect(workflow).toContain('force: true');
+    expect(workflow).toContain('git fetch --tags --force');
+    expect(workflow).toContain(
+      'Created canonical tag ${releaseTag} at ${checkoutRef}.'
     );
     expect(workflow).toContain(
-      'Legacy tag ${legacyTag} already exists at ${legacyTagSha}.'
+      'Legacy tag ${legacyTag} already exists at ${legacyTagSha}; leaving it unchanged.'
     );
-    expect(workflow).toContain('ref: `refs/tags/${releaseTag}`');
+    expect(workflow).toContain('ref: fullTagRef(releaseTag)');
     expect(workflow).toContain('Validate checksum manifest');
     expect(workflow).toContain('uses: softprops/action-gh-release@v2');
     expect(workflow).toContain('draft: true');


### PR DESCRIPTION
﻿## Summary
- build desktop release artifacts from the workflow trigger commit instead of an existing stale release tag
- keep duplicate-release detection before any tag mutation, then create or update only the canonical v<version> tag when no release exists
- add workflow-level release concurrency and update release workflow shape tests

## Root cause
The failed main release run reused the existing v2.0.0 tag SHA as the checkout ref when the tag existed but no GitHub release draft existed. That tag still pointed at an older commit, so the build jobs checked out stale code and failed before the draft release could be created.

## Validation
- pnpm vitest run tools/scripts/tauri/release/release.spec.ts
- git diff --check -- .github/workflows/release.yaml tools/scripts/tauri/release/release.spec.ts
- pre-commit hook: lint-staged plus repo test/coverage flow completed during commit
- review: test and implementation reviews were non-blocking; remaining notes are documented as release-operation residual risk
