### PR TITLE
[codex] fix release CI command resolution

### DIFF
--- a/tools/scripts/shared/process.spec.ts
+++ b/tools/scripts/shared/process.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   encodePowerShellCommand,
   getPnpmCommand,
+  getShellSafePackageManagerCommand,
   quoteWindowsArg,
   sanitizeEnv
 } from './process.ts';
@@ -10,6 +11,26 @@ describe('getPnpmCommand', () => {
   it('returns either pnpm or pnpm.cmd depending on platform', () => {
     const expected = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
     expect(getPnpmCommand()).toBe(expected);
+  });
+});
+
+describe('getShellSafePackageManagerCommand', () => {
+  it('runs package managers directly on POSIX hosts', () => {
+    expect(getShellSafePackageManagerCommand('npm', 'linux')).toEqual({
+      command: 'npm',
+      shell: false
+    });
+    expect(getShellSafePackageManagerCommand('pnpm', 'darwin')).toEqual({
+      command: 'pnpm',
+      shell: false
+    });
+  });
+
+  it('uses the Windows shell so package manager command shims resolve safely', () => {
+    expect(getShellSafePackageManagerCommand('pnpm', 'win32')).toEqual({
+      command: 'pnpm',
+      shell: true
+    });
   });
 });
 

--- a/tools/scripts/shared/process.ts
+++ b/tools/scripts/shared/process.ts
@@ -27,6 +27,11 @@ export type SyncCommandRunner = (
   input: SyncCommandRunnerInput
 ) => CommandResult;
 
+export interface ShellSafeCommand {
+  command: string;
+  shell: boolean;
+}
+
 export function runSyncCommand(input: SyncCommandRunnerInput): CommandResult {
   const result = spawnSync(input.command, input.args, {
     cwd: input.cwd,
@@ -69,6 +74,16 @@ export function runBestEffortSyncCommand(input: SyncCommandRunnerInput): void {
 
 export function getPnpmCommand(): string {
   return process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+}
+
+export function getShellSafePackageManagerCommand(
+  command: 'npm' | 'pnpm',
+  platform: NodeJS.Platform = process.platform
+): ShellSafeCommand {
+  return {
+    command,
+    shell: platform === 'win32'
+  };
 }
 
 export function sanitizeEnv(

--- a/tools/scripts/tauri/backend-runtime/backend-runtime.spec.ts
+++ b/tools/scripts/tauri/backend-runtime/backend-runtime.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { join } from 'node:path';
 import {
+  buildBackendRuntimeNpmCommand,
   buildBackendRuntimeInstallStamp,
   getBackendRuntimeInstallPlan,
   getBackendRuntimeStampPath
@@ -20,6 +21,24 @@ describe('getBackendRuntimeInstallPlan', () => {
       fallbackCommand: null,
       primaryCommand: 'install',
       removeLockfileBeforeFallback: false
+    });
+  });
+});
+
+describe('buildBackendRuntimeNpmCommand', () => {
+  it('uses npm directly on POSIX hosts', () => {
+    expect(buildBackendRuntimeNpmCommand('ci', 'linux')).toEqual({
+      command: 'npm',
+      args: ['ci', '--omit=dev', '--no-audit', '--no-fund'],
+      shell: false
+    });
+  });
+
+  it('uses shell mode on Windows so npm command shims resolve safely', () => {
+    expect(buildBackendRuntimeNpmCommand('install', 'win32')).toEqual({
+      command: 'npm',
+      args: ['install', '--omit=dev', '--no-audit', '--no-fund'],
+      shell: true
     });
   });
 });

--- a/tools/scripts/tauri/backend-runtime/backend-runtime.ts
+++ b/tools/scripts/tauri/backend-runtime/backend-runtime.ts
@@ -2,9 +2,9 @@ import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { getShellSafePackageManagerCommand } from '../../shared/process.ts';
 import {
   backendDistDir,
-  resolveNpmEntrypoint,
   resolveNxEntrypoint,
   workspaceRoot
 } from '../path-contract/path-contract.ts';
@@ -32,6 +32,14 @@ export interface BackendRuntimeInstallStamp {
   version: 1;
 }
 
+export interface BackendRuntimePackageManagerCommand {
+  args: string[];
+  command: string;
+  shell: boolean;
+}
+
+export type BackendRuntimeInstallCommand = 'ci' | 'install';
+
 export type HashFileFunction = (targetPath: string) => string;
 export type ReadTextFileFunction = (
   targetPath: string,
@@ -48,7 +56,6 @@ export interface PrepareBackendRuntimeDependencies {
   backendDir?: string;
   existsSyncFn?: typeof existsSync;
   hashFileFn?: HashFileFunction;
-  nodeExecPath?: string;
   nodeVersion?: string;
   platform?: NodeJS.Platform;
   readFileSyncFn?: ReadTextFileFunction;
@@ -80,6 +87,19 @@ export function getBackendRuntimeInstallPlan(
     fallbackCommand: null,
     primaryCommand: 'install',
     removeLockfileBeforeFallback: false
+  };
+}
+
+export function buildBackendRuntimeNpmCommand(
+  installCommand: BackendRuntimeInstallCommand,
+  platform: NodeJS.Platform = process.platform
+): BackendRuntimePackageManagerCommand {
+  const npmCommand = getShellSafePackageManagerCommand('npm', platform);
+
+  return {
+    command: npmCommand.command,
+    args: [installCommand, '--omit=dev', '--no-audit', '--no-fund'],
+    shell: npmCommand.shell
   };
 }
 
@@ -209,7 +229,6 @@ export function prepareBackendRuntime(
   const arch = dependencies.arch ?? process.arch;
   const existsSyncFn = dependencies.existsSyncFn ?? existsSync;
   const hashFileFn = dependencies.hashFileFn ?? hashFile;
-  const nodeExecPath = dependencies.nodeExecPath ?? process.execPath;
   const nodeVersion = dependencies.nodeVersion ?? process.version;
   const platform = dependencies.platform ?? process.platform;
   const readFileSyncFn =
@@ -257,15 +276,19 @@ export function prepareBackendRuntime(
   const installPlan = getBackendRuntimeInstallPlan(
     existsSyncFn(packageLockPath)
   );
-  const primaryArgs = [
-    resolveNpmEntrypoint(nodeExecPath),
+  const primaryCommand = buildBackendRuntimeNpmCommand(
     installPlan.primaryCommand,
-    '--omit=dev',
-    '--no-audit',
-    '--no-fund'
-  ];
+    platform
+  );
 
-  if (tryRunFn(nodeExecPath, primaryArgs, backendDir)) {
+  if (
+    tryRunFn(
+      primaryCommand.command,
+      primaryCommand.args,
+      backendDir,
+      primaryCommand.shell
+    )
+  ) {
     writeBackendRuntimeInstallStamp(
       stampPath,
       buildBackendRuntimeInstallStamp(backendDir, {
@@ -281,7 +304,11 @@ export function prepareBackendRuntime(
   }
 
   if (!installPlan.fallbackCommand) {
-    throw new Error(`Command failed: ${nodeExecPath} ${primaryArgs.join(' ')}`);
+    throw new Error(
+      `Command failed: ${primaryCommand.command} ${primaryCommand.args.join(
+        ' '
+      )}`
+    );
   }
 
   removePathFn(join(backendDir, 'node_modules'));
@@ -292,16 +319,15 @@ export function prepareBackendRuntime(
   warnFn(
     `npm ci failed in ${backendDir}. Falling back to npm install to regenerate runtime dependencies.`
   );
+  const fallbackCommand = buildBackendRuntimeNpmCommand(
+    installPlan.fallbackCommand,
+    platform
+  );
   runFn(
-    nodeExecPath,
-    [
-      resolveNpmEntrypoint(nodeExecPath),
-      installPlan.fallbackCommand,
-      '--omit=dev',
-      '--no-audit',
-      '--no-fund'
-    ],
-    backendDir
+    fallbackCommand.command,
+    fallbackCommand.args,
+    backendDir,
+    fallbackCommand.shell
   );
   writeBackendRuntimeInstallStamp(
     stampPath,

--- a/tools/scripts/tauri/path-contract/path-contract.spec.ts
+++ b/tools/scripts/tauri/path-contract/path-contract.spec.ts
@@ -2,18 +2,12 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { resolveNpmEntrypoint, resolveNxEntrypoint } from './path-contract.ts';
+import { resolveNxEntrypoint } from './path-contract.ts';
 
 describe('path-contract', () => {
   it('resolves the Nx entrypoint from the workspace root', () => {
     expect(resolveNxEntrypoint('workspace-root')).toBe(
       join('workspace-root', 'node_modules', 'nx', 'bin', 'nx.js')
-    );
-  });
-
-  it('resolves the npm CLI entrypoint relative to the Node executable', () => {
-    expect(resolveNpmEntrypoint(join('workspace-root', 'node.exe'))).toBe(
-      join('workspace-root', 'node_modules', 'npm', 'bin', 'npm-cli.js')
     );
   });
 });

--- a/tools/scripts/tauri/path-contract/path-contract.ts
+++ b/tools/scripts/tauri/path-contract/path-contract.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
 import { resolveWorkspaceRootFromModuleUrl } from '../../shared/paths.ts';
 
@@ -22,14 +22,4 @@ export const backendDistDir = join(
 
 export function resolveNxEntrypoint(rootDir = workspaceRoot) {
   return join(rootDir, 'node_modules', 'nx', 'bin', 'nx.js');
-}
-
-export function resolveNpmEntrypoint(nodeExecPath = process.execPath) {
-  return join(
-    dirname(nodeExecPath),
-    'node_modules',
-    'npm',
-    'bin',
-    'npm-cli.js'
-  );
 }

--- a/tools/scripts/tauri/prepare-runtime/prepare-runtime.spec.ts
+++ b/tools/scripts/tauri/prepare-runtime/prepare-runtime.spec.ts
@@ -206,8 +206,8 @@ describe('prepareBackendRuntime', () => {
 
     expect(removedPaths).toEqual([nodeModulesPath]);
     expect(tryRunCalls).toHaveLength(1);
-    expect(tryRunCalls[0]?.args[1]).toBe('install');
-    expect(tryRunCalls[0]?.args.slice(2)).toEqual(npmRuntimeFlags);
+    expect(tryRunCalls[0]?.args[0]).toBe('install');
+    expect(tryRunCalls[0]?.args.slice(1)).toEqual(npmRuntimeFlags);
     expect(writtenFiles).toHaveLength(1);
     expect(writtenFiles[0]?.path).toBe(stampPath);
   });
@@ -253,8 +253,8 @@ describe('prepareBackendRuntime', () => {
     });
 
     expect(tryRunCalls).toHaveLength(1);
-    expect(tryRunCalls[0]?.args[1]).toBe('install');
-    expect(tryRunCalls[0]?.args.slice(2)).toEqual(npmRuntimeFlags);
+    expect(tryRunCalls[0]?.args[0]).toBe('install');
+    expect(tryRunCalls[0]?.args.slice(1)).toEqual(npmRuntimeFlags);
     expect(writtenFiles).toHaveLength(1);
     expect(writtenFiles[0]?.path).toBe(stampPath);
     expect(JSON.parse(writtenFiles[0]?.content ?? '{}')).toEqual(
@@ -352,8 +352,8 @@ describe('prepareBackendRuntime', () => {
 
       expect(tryRunCalls).toHaveLength(1);
       expect(tryRunCalls[0]?.cwd).toBe(backendDir);
-      expect(tryRunCalls[0]?.args[1]).toBe('install');
-      expect(tryRunCalls[0]?.args.slice(2)).toEqual(npmRuntimeFlags);
+      expect(tryRunCalls[0]?.args[0]).toBe('install');
+      expect(tryRunCalls[0]?.args.slice(1)).toEqual(npmRuntimeFlags);
       expect(writtenFiles).toHaveLength(1);
       expect(writtenFiles[0]?.path).toBe(stampPath);
       expect(JSON.parse(writtenFiles[0]?.content ?? '{}')).toEqual(
@@ -410,8 +410,8 @@ describe('prepareBackendRuntime', () => {
 
     expect(tryRunCalls).toHaveLength(1);
     expect(tryRunCalls[0]?.cwd).toBe(backendDir);
-    expect(tryRunCalls[0]?.args[1]).toBe('ci');
-    expect(tryRunCalls[0]?.args.slice(2)).toEqual(npmRuntimeFlags);
+    expect(tryRunCalls[0]?.args[0]).toBe('ci');
+    expect(tryRunCalls[0]?.args.slice(1)).toEqual(npmRuntimeFlags);
     expect(writtenFiles).toHaveLength(1);
     expect(writtenFiles[0]?.path).toBe(stampPath);
   });
@@ -466,12 +466,11 @@ describe('prepareBackendRuntime', () => {
     );
     expect(tryRunCalls).toHaveLength(1);
     expect(tryRunCalls[0]).toMatchObject({
-      command: process.execPath,
+      command: 'npm',
       cwd: backendDir
     });
-    expect(tryRunCalls[0]?.args[0]).toContain('npm-cli.js');
-    expect(tryRunCalls[0]?.args[1]).toBe('ci');
-    expect(tryRunCalls[0]?.args.slice(2)).toEqual(npmRuntimeFlags);
+    expect(tryRunCalls[0]?.args[0]).toBe('ci');
+    expect(tryRunCalls[0]?.args.slice(1)).toEqual(npmRuntimeFlags);
     expect(runCalls).toEqual([]);
     expect(warnings).toEqual([]);
     expect(writtenFiles).toHaveLength(1);
@@ -483,7 +482,7 @@ describe('prepareBackendRuntime', () => {
     );
   });
 
-  it('uses an injected node executable when preparing runtime dependencies', () => {
+  it('uses the npm command when preparing runtime dependencies', () => {
     const backendDir = 'backend-dist-test';
     const packageJsonPath = join(backendDir, 'package.json');
     const tryRunCalls: Array<{
@@ -499,7 +498,6 @@ describe('prepareBackendRuntime', () => {
       existsSyncFn(targetPath) {
         return targetPath === packageJsonPath;
       },
-      nodeExecPath: 'injected-node.exe',
       removePathFn() {
         return undefined;
       },
@@ -520,7 +518,7 @@ describe('prepareBackendRuntime', () => {
 
     expect(tryRunCalls).toHaveLength(1);
     expect(tryRunCalls[0]).toMatchObject({
-      command: 'injected-node.exe',
+      command: 'npm',
       cwd: backendDir
     });
     expect(writtenFiles).toHaveLength(1);
@@ -580,12 +578,11 @@ describe('prepareBackendRuntime', () => {
       expect.arrayContaining([packageJsonPath, packageLockPath])
     );
     expect(tryRunCalls[0]).toMatchObject({
-      command: process.execPath,
+      command: 'npm',
       cwd: backendDir
     });
-    expect(tryRunCalls[0]?.args[0]).toContain('npm-cli.js');
-    expect(tryRunCalls[0]?.args[1]).toBe('ci');
-    expect(tryRunCalls[0]?.args.slice(2)).toEqual(npmRuntimeFlags);
+    expect(tryRunCalls[0]?.args[0]).toBe('ci');
+    expect(tryRunCalls[0]?.args.slice(1)).toEqual(npmRuntimeFlags);
     expect(removedPaths).toEqual([
       nodeModulesPath,
       nodeModulesPath,
@@ -593,12 +590,11 @@ describe('prepareBackendRuntime', () => {
     ]);
     expect(runCalls).toHaveLength(1);
     expect(runCalls[0]).toMatchObject({
-      command: process.execPath,
+      command: 'npm',
       cwd: backendDir
     });
-    expect(runCalls[0]?.args[0]).toContain('npm-cli.js');
-    expect(runCalls[0]?.args[1]).toBe('install');
-    expect(runCalls[0]?.args.slice(2)).toEqual(npmRuntimeFlags);
+    expect(runCalls[0]?.args[0]).toBe('install');
+    expect(runCalls[0]?.args.slice(1)).toEqual(npmRuntimeFlags);
     expect(warnings).toEqual([
       `npm ci failed in ${backendDir}. Falling back to npm install to regenerate runtime dependencies.`
     ]);
@@ -663,12 +659,11 @@ describe('prepareBackendRuntime', () => {
     );
     expect(tryRunCalls).toHaveLength(1);
     expect(tryRunCalls[0]).toMatchObject({
-      command: process.execPath,
+      command: 'npm',
       cwd: backendDir
     });
-    expect(tryRunCalls[0]?.args[0]).toContain('npm-cli.js');
-    expect(tryRunCalls[0]?.args[1]).toBe('install');
-    expect(tryRunCalls[0]?.args.slice(2)).toEqual(npmRuntimeFlags);
+    expect(tryRunCalls[0]?.args[0]).toBe('install');
+    expect(tryRunCalls[0]?.args.slice(1)).toEqual(npmRuntimeFlags);
     expect(runCalls).toEqual([]);
     expect(warnings).toEqual([]);
     expect(writtenFiles).toHaveLength(1);
@@ -708,7 +703,7 @@ describe('prepareBackendRuntime', () => {
           return undefined;
         }
       })
-    ).toThrow(`Command failed: ${process.execPath}`);
+    ).toThrow('Command failed: npm install --omit=dev --no-audit --no-fund');
 
     expect(removedPaths).toEqual([join(backendDir, 'node_modules')]);
     expect(runCalls).toEqual([]);
@@ -744,7 +739,7 @@ describe('prepareBackendRuntime', () => {
           warnings.push(message);
         }
       })
-    ).toThrow(`Command failed: ${process.execPath}`);
+    ).toThrow('Command failed: npm install --omit=dev --no-audit --no-fund');
 
     expect(removedPaths).toEqual([
       nodeModulesPath,

--- a/tools/scripts/tauri/process-utils/process-utils.spec.ts
+++ b/tools/scripts/tauri/process-utils/process-utils.spec.ts
@@ -69,6 +69,31 @@ describe('process-utils', () => {
     );
   });
 
+  it('forwards shell mode when running commands', async () => {
+    const spawnSync = vi.fn(() => ({
+      error: undefined,
+      status: 0
+    }));
+
+    vi.doMock('node:child_process', () => ({
+      spawnSync
+    }));
+
+    const { run } = await import('./process-utils.ts');
+
+    run('pnpm', ['exec', 'tauri'], 'workspace-root', true);
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      'pnpm',
+      ['exec', 'tauri'],
+      expect.objectContaining({
+        cwd: 'workspace-root',
+        shell: true,
+        stdio: 'inherit'
+      })
+    );
+  });
+
   it('throws a command failure error when the process exits non-zero', async () => {
     const spawnSync = vi.fn(() => ({
       error: undefined,
@@ -129,6 +154,30 @@ describe('process-utils', () => {
     );
   });
 
+  it('forwards shell mode when best-effort probing commands', async () => {
+    const spawnSync = vi.fn(() => ({
+      error: undefined,
+      status: 0
+    }));
+
+    vi.doMock('node:child_process', () => ({
+      spawnSync
+    }));
+
+    const { tryRun } = await import('./process-utils.ts');
+
+    expect(tryRun('npm', ['install'], 'workspace-root', true)).toBe(true);
+    expect(spawnSync).toHaveBeenCalledWith(
+      'npm',
+      ['install'],
+      expect.objectContaining({
+        cwd: 'workspace-root',
+        shell: true,
+        stdio: 'inherit'
+      })
+    );
+  });
+
   it('returns true from tryRun when the process exits cleanly', async () => {
     const spawnSync = vi.fn(() => ({
       error: undefined,
@@ -180,6 +229,31 @@ describe('process-utils', () => {
       expect.objectContaining({
         cwd: 'workspace-root',
         shell: false,
+        stdio: 'ignore'
+      })
+    );
+  });
+
+  it('forwards shell mode when running best-effort commands', async () => {
+    const spawnSync = vi.fn(() => ({
+      error: undefined,
+      status: 0
+    }));
+
+    vi.doMock('node:child_process', () => ({
+      spawnSync
+    }));
+
+    const { runBestEffort } = await import('./process-utils.ts');
+
+    runBestEffort('pnpm', ['prune'], 'workspace-root', true);
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      'pnpm',
+      ['prune'],
+      expect.objectContaining({
+        cwd: 'workspace-root',
+        shell: true,
         stdio: 'ignore'
       })
     );

--- a/tools/scripts/tauri/process-utils/process-utils.ts
+++ b/tools/scripts/tauri/process-utils/process-utils.ts
@@ -10,12 +10,14 @@ export type RemovePathFunction = (targetPath: string) => void;
 export type RunFunction = (
   command: string,
   args: string[],
-  cwd: string
+  cwd: string,
+  shell?: boolean
 ) => void;
 export type TryRunFunction = (
   command: string,
   args: string[],
-  cwd: string
+  cwd: string,
+  shell?: boolean
 ) => boolean;
 
 export function rmIfExists(targetPath: string) {
@@ -24,29 +26,47 @@ export function rmIfExists(targetPath: string) {
   }
 }
 
-export function run(command: string, args: string[], cwd: string) {
+export function run(
+  command: string,
+  args: string[],
+  cwd: string,
+  shell = false
+) {
   runSyncCommandOrThrow({
     command,
     args,
     cwd,
+    shell,
     stdio: 'inherit'
   });
 }
 
-export function tryRun(command: string, args: string[], cwd: string) {
+export function tryRun(
+  command: string,
+  args: string[],
+  cwd: string,
+  shell = false
+) {
   return tryRunSyncCommand({
     command,
     args,
     cwd,
+    shell,
     stdio: 'inherit'
   });
 }
 
-export function runBestEffort(command: string, args: string[], cwd: string) {
+export function runBestEffort(
+  command: string,
+  args: string[],
+  cwd: string,
+  shell = false
+) {
   runBestEffortSyncCommand({
     command,
     args,
     cwd,
+    shell,
     stdio: 'ignore'
   });
 }

--- a/tools/scripts/tauri/release/release.spec.ts
+++ b/tools/scripts/tauri/release/release.spec.ts
@@ -17,6 +17,7 @@ import {
   buildStableReleaseTag,
   buildArtifactName,
   buildAssetFileName,
+  buildTauriBundleCommand,
   createChecksumFileContents,
   parseStableReleaseTag,
   readVersionAuthorities,
@@ -168,6 +169,40 @@ describe('release helper', () => {
     expect(resolveReleasePlatform(undefined, 'win32')).toBe('windows');
     expect(resolveReleasePlatform(undefined, 'darwin')).toBe('macos');
     expect(resolveReleasePlatform(undefined, 'linux')).toBe('linux');
+  });
+
+  it('builds a POSIX-safe Tauri bundle command', () => {
+    expect(buildTauriBundleCommand('linux', 'linux')).toEqual({
+      command: 'pnpm',
+      args: [
+        'exec',
+        'tauri',
+        'build',
+        '--config',
+        'apps/desktop-tauri/src-tauri/tauri.conf.json',
+        '--bundles',
+        'appimage',
+        '--ci'
+      ],
+      shell: false
+    });
+  });
+
+  it('builds a Windows shell-safe Tauri bundle command', () => {
+    expect(buildTauriBundleCommand('windows', 'win32')).toEqual({
+      command: 'pnpm',
+      args: [
+        'exec',
+        'tauri',
+        'build',
+        '--config',
+        'apps/desktop-tauri/src-tauri/tauri.conf.json',
+        '--bundles',
+        'nsis',
+        '--ci'
+      ],
+      shell: true
+    });
   });
 
   it('formats checksum files in release order', () => {

--- a/tools/scripts/tauri/release/release.ts
+++ b/tools/scripts/tauri/release/release.ts
@@ -16,7 +16,10 @@ import { basename, dirname, join } from 'node:path';
 
 import archiver from 'archiver';
 
-import { getPnpmCommand, runSyncCommandOrThrow } from '../../shared/process.ts';
+import {
+  getShellSafePackageManagerCommand,
+  runSyncCommandOrThrow
+} from '../../shared/process.ts';
 import { isDirectEntrypoint } from '../../shared/paths.ts';
 import { getRustTargetTriple } from '../node-sidecar/node-sidecar.ts';
 import { workspaceRoot } from '../path-contract/path-contract.ts';
@@ -52,6 +55,12 @@ export interface ReleaseManifest {
   rustTargetTriple: string;
   sha256: string;
   version: string;
+}
+
+export interface TauriBundleCommand {
+  args: string[];
+  command: string;
+  shell: boolean;
 }
 
 export const releaseArtifactDefinitions: Record<
@@ -258,6 +267,28 @@ export function resolveReleasePlatform(
   throw new Error(
     `Unable to infer a release platform for host platform "${hostPlatform}".`
   );
+}
+
+export function buildTauriBundleCommand(
+  platform: ReleasePlatform,
+  hostPlatform: NodeJS.Platform = process.platform
+): TauriBundleCommand {
+  const pnpmCommand = getShellSafePackageManagerCommand('pnpm', hostPlatform);
+
+  return {
+    command: pnpmCommand.command,
+    args: [
+      'exec',
+      'tauri',
+      'build',
+      '--config',
+      tauriConfigRelativePath,
+      '--bundles',
+      releaseArtifactDefinitions[platform].bundleTarget,
+      '--ci'
+    ],
+    shell: pnpmCommand.shell
+  };
 }
 
 export function buildArtifactName(version: string, platform: ReleasePlatform) {
@@ -585,20 +616,13 @@ async function bundleReleaseArtifact(args: string[]) {
 
   const releaseDirectory = resolveReleaseDirectory(platform);
   removeAndRecreateDirectory(releaseDirectory);
+  const bundleCommand = buildTauriBundleCommand(platform);
 
   runSyncCommandOrThrow({
-    args: [
-      'exec',
-      'tauri',
-      'build',
-      '--config',
-      tauriConfigRelativePath,
-      '--bundles',
-      releaseArtifactDefinitions[platform].bundleTarget,
-      '--ci'
-    ],
-    command: getPnpmCommand(),
+    args: bundleCommand.args,
+    command: bundleCommand.command,
     cwd: workspaceRoot,
+    shell: bundleCommand.shell,
     stdio: 'inherit'
   });
 


### PR DESCRIPTION
﻿## Summary
- Fix desktop release CI command resolution for npm/pnpm on GitHub-hosted runners.
- Stop resolving npm from Node's install directory and use PATH-based npm instead.
- Run Windows package-manager commands through shell mode so `.cmd` shims resolve safely.

## Root Cause
The main-branch release workflow reached `prepare-release`, but all `build-desktop` jobs failed, so `publish-release` skipped and no draft release was created. macOS/Linux failed because the scripts expected `npm-cli.js` under the hosted Node install directory. Windows failed because `pnpm.cmd` was spawned without shell mode.

## Validation
- `git diff --check`
- `pnpm vitest run tools/scripts/shared/process.spec.ts tools/scripts/tauri/process-utils/process-utils.spec.ts tools/scripts/tauri/path-contract/path-contract.spec.ts tools/scripts/tauri/backend-runtime/backend-runtime.spec.ts tools/scripts/tauri/prepare-runtime/prepare-runtime.spec.ts tools/scripts/tauri/release/release.spec.ts` (104 tests passed)
- `pnpm review:test`
- `pnpm review:checkpoint -- --checkpoint implementation --provider auto --focus release-ci-command-resolution --context-file <temp-context>`
- pre-commit hook completed lint-staged and the repo coverage test chain during commit

## Known Follow-Up
- `pnpm exec tsc -p tools/scripts/tsconfig.json --noEmit` is still blocked by pre-existing review-gate union narrowing errors in `tools/scripts/review-gate/shared/shared.ts` and `tools/scripts/review-gate/status/status.ts`.
- Implementation review reported non-blocking P3 follow-ups to eventually consolidate package-manager command helpers and document shell-mode quoting expectations more explicitly.
