### PR TITLE
Fix release artifact CI validation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -239,7 +239,8 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev librsvg2-bin patchelf
+          sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2
       - name: Setup pnpm
         run: |
           corepack enable
@@ -254,33 +255,7 @@ jobs:
       - name: Build Tauri desktop bundle
         run: pnpm nx run ${{ matrix.nx_target }}
       - name: Validate assembled release artifact
-        run: |
-          node --input-type=module -e "
-          import { existsSync } from 'node:fs';
-          import { join } from 'node:path';
-
-          const platform = process.env.RELEASE_PLATFORM;
-          const assetFileName = process.env.ASSET_FILE_NAME;
-
-          if (!platform || !assetFileName) {
-            throw new Error('RELEASE_PLATFORM and ASSET_FILE_NAME are required.');
-          }
-
-          const releaseDirectory = join(process.cwd(), 'dist', 'release-assets', platform);
-          const manifestPath = join(releaseDirectory, 'release-manifest.json');
-          const assetPath = join(releaseDirectory, assetFileName);
-
-          for (const candidatePath of [releaseDirectory, manifestPath, assetPath]) {
-            if (!existsSync(candidatePath)) {
-              throw new Error(\`Expected \${candidatePath} to exist.\`);
-            }
-          }
-
-          console.log(JSON.stringify({ releaseDirectory, manifestPath, assetPath }, null, 2));
-          "
-        env:
-          ASSET_FILE_NAME: ${{ steps.release_context.outputs.asset_file_name }}
-          RELEASE_PLATFORM: ${{ matrix.platform }}
+        run: node tools/scripts/tauri/release/release.ts validate-artifact --platform ${{ matrix.platform }} --release-tag ${{ needs.prepare-release.outputs.release_tag }}
       - name: Upload Tauri bundle artifact
         uses: actions/upload-artifact@v4
         with:

--- a/tools/scripts/tauri/release/release.spec.ts
+++ b/tools/scripts/tauri/release/release.spec.ts
@@ -22,6 +22,7 @@ import {
   parseStableReleaseTag,
   readVersionAuthorities,
   resolveReleasePlatform,
+  validateReleaseArtifact,
   type ReleaseManifest
 } from './release.ts';
 
@@ -98,6 +99,7 @@ function writeFixtureArtifact(
   platformDefinition: (typeof fixturePlatformDefinitions)[number],
   options: {
     assetContents?: string;
+    directoryName?: string;
     invalidManifestContents?: string;
     manifestOverrides?: Partial<ReleaseManifest>;
     skipAsset?: boolean;
@@ -107,7 +109,10 @@ function writeFixtureArtifact(
     fixtureVersion,
     platformDefinition.platform
   );
-  const artifactDirectory = join(artifactsRoot, artifactName);
+  const artifactDirectory = join(
+    artifactsRoot,
+    options.directoryName ?? artifactName
+  );
   const assetContents =
     options.assetContents ?? `${platformDefinition.content}\n`;
   const manifest = createReleaseManifest(
@@ -257,6 +262,133 @@ describe('release helper', () => {
     expect(assertVersionAuthoritiesInSync(fixtureVersion)).toBe(fixtureVersion);
   });
 
+  it('validates a platform release artifact produced by the bundle step', async () => {
+    const artifactsRoot = createFixtureDirectory();
+    const platformDefinition = fixturePlatformDefinitions[0];
+    const fixture = writeFixtureArtifact(artifactsRoot, platformDefinition, {
+      directoryName: platformDefinition.platform
+    });
+
+    const result = await validateReleaseArtifact(
+      platformDefinition.platform,
+      fixtureVersion,
+      artifactsRoot
+    );
+
+    expect(result.assetPath).toBe(fixture.assetPath);
+    expect(result.manifestPath).toBe(fixture.manifestPath);
+    expect(result.releaseDirectory).toBe(fixture.artifactDirectory);
+    expect(result.manifest).toEqual(fixture.manifest);
+  });
+
+  it('fails platform release validation when the manifest asset name is wrong', async () => {
+    const artifactsRoot = createFixtureDirectory();
+    const platformDefinition = fixturePlatformDefinitions[2];
+
+    writeFixtureArtifact(artifactsRoot, platformDefinition, {
+      directoryName: platformDefinition.platform,
+      manifestOverrides: {
+        assetFileName: 'wrong-linux-artifact.AppImage'
+      }
+    });
+
+    await expect(
+      validateReleaseArtifact(
+        platformDefinition.platform,
+        fixtureVersion,
+        artifactsRoot
+      )
+    ).rejects.toThrow(/declared asset file wrong-linux-artifact\.AppImage/u);
+  });
+
+  it('fails platform release validation when the asset is missing', async () => {
+    const artifactsRoot = createFixtureDirectory();
+    const platformDefinition = fixturePlatformDefinitions[1];
+
+    writeFixtureArtifact(artifactsRoot, platformDefinition, {
+      directoryName: platformDefinition.platform,
+      skipAsset: true
+    });
+
+    await expect(
+      validateReleaseArtifact(
+        platformDefinition.platform,
+        fixtureVersion,
+        artifactsRoot
+      )
+    ).rejects.toThrow(
+      /Expected asset .* referenced by .*release-manifest\.json/u
+    );
+  });
+
+  it('fails platform release validation when the release directory is missing', async () => {
+    const artifactsRoot = createFixtureDirectory();
+    const platformDefinition = fixturePlatformDefinitions[0];
+
+    await expect(
+      validateReleaseArtifact(
+        platformDefinition.platform,
+        fixtureVersion,
+        artifactsRoot
+      )
+    ).rejects.toThrow(/Expected .*windows.* to exist/u);
+  });
+
+  it('fails platform release validation when the manifest is missing', async () => {
+    const artifactsRoot = createFixtureDirectory();
+    const platformDefinition = fixturePlatformDefinitions[2];
+
+    mkdirSync(join(artifactsRoot, platformDefinition.platform), {
+      recursive: true
+    });
+
+    await expect(
+      validateReleaseArtifact(
+        platformDefinition.platform,
+        fixtureVersion,
+        artifactsRoot
+      )
+    ).rejects.toThrow(/Expected .*release-manifest\.json.* to exist/u);
+  });
+
+  it('fails platform release validation when the manifest is malformed JSON', async () => {
+    const artifactsRoot = createFixtureDirectory();
+    const platformDefinition = fixturePlatformDefinitions[0];
+
+    writeFixtureArtifact(artifactsRoot, platformDefinition, {
+      directoryName: platformDefinition.platform,
+      invalidManifestContents: '{"artifactName":'
+    });
+
+    await expect(
+      validateReleaseArtifact(
+        platformDefinition.platform,
+        fixtureVersion,
+        artifactsRoot
+      )
+    ).rejects.toThrow();
+  });
+
+  it('fails platform release validation when the checksum does not match', async () => {
+    const artifactsRoot = createFixtureDirectory();
+    const platformDefinition = fixturePlatformDefinitions[2];
+
+    writeFixtureArtifact(artifactsRoot, platformDefinition, {
+      directoryName: platformDefinition.platform,
+      manifestOverrides: {
+        sha256: hashContent('checksum-from-a-different-artifact\n')
+      }
+    });
+
+    await expect(
+      validateReleaseArtifact(
+        platformDefinition.platform,
+        fixtureVersion,
+        artifactsRoot
+      )
+    ).rejects.toThrow(/Checksum mismatch/u);
+  });
+
   it('assembles validated release assets from downloaded artifacts', async () => {
     const artifactsRoot = createFixtureDirectory();
     const outputDirectory = createFixtureDirectory();
@@ -372,6 +504,24 @@ describe('release helper', () => {
     expect(workflow).toContain('nx_target: desktop-tauri:bundle-windows');
     expect(workflow).toContain('nx_target: desktop-tauri:bundle-macos');
     expect(workflow).toContain('nx_target: desktop-tauri:bundle-linux');
+    expect(workflow).toContain('librsvg2-bin');
+    expect(workflow).toContain(
+      'sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2'
+    );
+    expect(workflow).toContain(
+      'node tools/scripts/tauri/release/release.ts validate-artifact --platform ${{ matrix.platform }} --release-tag ${{ needs.prepare-release.outputs.release_tag }}'
+    );
+    expect(workflow).toMatch(
+      /- name: Validate assembled release artifact\r?\n\s+run: node tools\/scripts\/tauri\/release\/release\.ts validate-artifact --platform \$\{\{ matrix\.platform \}\} --release-tag \$\{\{ needs\.prepare-release\.outputs\.release_tag \}\}/u
+    );
+    expect(workflow).not.toMatch(
+      /- name: Validate assembled release artifact\r?\n\s+run: \|\r?\n\s+node --input-type=module -e/u
+    );
+    expect(workflow).not.toContain('ASSET_FILE_NAME:');
+    expect(workflow).not.toContain('RELEASE_PLATFORM:');
+    expect(workflow).not.toContain(
+      'const assetFileName = process.env.ASSET_FILE_NAME;'
+    );
     expect(workflow).toMatch(
       /publish-release:\s+needs:\s+- prepare-release\s+- build-desktop/su
     );

--- a/tools/scripts/tauri/release/release.ts
+++ b/tools/scripts/tauri/release/release.ts
@@ -57,6 +57,13 @@ export interface ReleaseManifest {
   version: string;
 }
 
+export interface ReleaseArtifactValidationResult {
+  assetPath: string;
+  manifest: ReleaseManifest;
+  manifestPath: string;
+  releaseDirectory: string;
+}
+
 export interface TauriBundleCommand {
   args: string[];
   command: string;
@@ -457,6 +464,74 @@ function readReleaseManifest(manifestPath: string): ReleaseManifest {
   return readJsonFile<ReleaseManifest>(manifestPath);
 }
 
+export async function validateReleaseArtifact(
+  platform: ReleasePlatform,
+  expectedVersion: string,
+  assetsRoot = releaseAssetsRoot
+): Promise<ReleaseArtifactValidationResult> {
+  const releaseDirectory = join(assetsRoot, platform);
+  const manifestPath = join(releaseDirectory, releaseManifestFileName);
+  const expectedAssetFileName = buildAssetFileName(expectedVersion, platform);
+  const expectedArtifactName = buildArtifactName(expectedVersion, platform);
+
+  for (const candidatePath of [releaseDirectory, manifestPath]) {
+    if (!existsSync(candidatePath)) {
+      throw new Error(`Expected ${candidatePath} to exist.`);
+    }
+  }
+
+  const manifest = readReleaseManifest(manifestPath);
+
+  if (manifest.platform !== platform) {
+    throw new Error(
+      `Manifest ${manifestPath} declared platform ${manifest.platform} but ${platform} was expected.`
+    );
+  }
+
+  if (manifest.version !== expectedVersion) {
+    throw new Error(
+      `Manifest ${manifestPath} declared version ${manifest.version} but ${expectedVersion} was expected.`
+    );
+  }
+
+  if (manifest.assetFileName !== expectedAssetFileName) {
+    throw new Error(
+      `Manifest ${manifestPath} declared asset file ${manifest.assetFileName} but ${expectedAssetFileName} was expected.`
+    );
+  }
+
+  if (manifest.artifactName !== expectedArtifactName) {
+    throw new Error(
+      `Manifest ${manifestPath} declared artifact name ${manifest.artifactName} but ${expectedArtifactName} was expected.`
+    );
+  }
+
+  const assetPath = join(releaseDirectory, manifest.assetFileName);
+
+  if (!existsSync(assetPath)) {
+    throw new Error(
+      `Expected asset ${assetPath} referenced by ${manifestPath}.`
+    );
+  }
+
+  const computedSha = await hashFile(assetPath);
+  if (computedSha !== manifest.sha256) {
+    throw new Error(
+      `Checksum mismatch for ${assetPath}. Expected ${manifest.sha256}, computed ${computedSha}.`
+    );
+  }
+
+  return {
+    assetPath,
+    manifest: {
+      ...manifest,
+      sha256: computedSha
+    },
+    manifestPath,
+    releaseDirectory
+  };
+}
+
 function walkForFiles(targetPath: string, fileName: string): string[] {
   if (!existsSync(targetPath)) {
     return [];
@@ -676,6 +751,21 @@ async function assembleRelease(args: string[]) {
   );
 }
 
+async function validateReleaseArtifactCommand(args: string[]) {
+  const platform = resolveReleasePlatform(getArgumentValue('--platform', args));
+  const releaseTag = getArgumentValue('--release-tag', args);
+
+  if (!releaseTag) {
+    throw new Error('validate-artifact requires --release-tag <stable-tag>.');
+  }
+
+  const expectedVersion = parseStableReleaseTag(releaseTag);
+  assertVersionAuthoritiesInSync(expectedVersion);
+  const result = await validateReleaseArtifact(platform, expectedVersion);
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
 async function main() {
   const [command, ...args] = process.argv.slice(2);
 
@@ -689,8 +779,13 @@ async function main() {
     case 'describe':
       await describeRelease(args);
       break;
+    case 'validate-artifact':
+      await validateReleaseArtifactCommand(args);
+      break;
     default:
-      throw new Error('Expected one of: describe, bundle, assemble.');
+      throw new Error(
+        'Expected one of: describe, bundle, assemble, validate-artifact.'
+      );
   }
 }
 


### PR DESCRIPTION
## Summary
- install the Linux AppImage/FUSE compatibility dependencies needed by the desktop release bundle job
- move the fragile Windows inline artifact validation into the release TypeScript helper
- add validator and workflow-shape tests for the release artifact contract

## Verification
- pnpm vitest run tools/scripts/tauri/release/release.spec.ts
- git diff --check
- pnpm review:test
- pnpm review:implementation
- pre-commit hook: lint-staged + nx test coverage suite completed during commit

## Release note
This PR fixes the failed main Desktop Release run. The draft release is still expected to appear only after this PR is merged into main and the push-to-main Desktop Release workflow runs again.
