### PR TITLE
Fix Linux AppImage release CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -239,8 +239,25 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev librsvg2-bin patchelf
+          sudo apt-get install -y \
+            build-essential \
+            curl \
+            desktop-file-utils \
+            file \
+            libappindicator3-dev \
+            librsvg2-bin \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            patchelf \
+            squashfs-tools \
+            wget
           sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2
+          command -v desktop-file-validate
+          command -v file
+          command -v mksquashfs
+          command -v patchelf
       - name: Setup pnpm
         run: |
           corepack enable

--- a/tools/scripts/tauri/release/release.spec.ts
+++ b/tools/scripts/tauri/release/release.spec.ts
@@ -187,7 +187,8 @@ describe('release helper', () => {
         'apps/desktop-tauri/src-tauri/tauri.conf.json',
         '--bundles',
         'appimage',
-        '--ci'
+        '--ci',
+        '--verbose'
       ],
       shell: false
     });
@@ -504,10 +505,16 @@ describe('release helper', () => {
     expect(workflow).toContain('nx_target: desktop-tauri:bundle-windows');
     expect(workflow).toContain('nx_target: desktop-tauri:bundle-macos');
     expect(workflow).toContain('nx_target: desktop-tauri:bundle-linux');
+    expect(workflow).toContain('desktop-file-utils');
+    expect(workflow).toContain('squashfs-tools');
     expect(workflow).toContain('librsvg2-bin');
     expect(workflow).toContain(
       'sudo apt-get install -y libfuse2t64 || sudo apt-get install -y libfuse2'
     );
+    expect(workflow).toContain('command -v desktop-file-validate');
+    expect(workflow).toContain('command -v file');
+    expect(workflow).toContain('command -v mksquashfs');
+    expect(workflow).toContain('command -v patchelf');
     expect(workflow).toContain(
       'node tools/scripts/tauri/release/release.ts validate-artifact --platform ${{ matrix.platform }} --release-tag ${{ needs.prepare-release.outputs.release_tag }}'
     );

--- a/tools/scripts/tauri/release/release.ts
+++ b/tools/scripts/tauri/release/release.ts
@@ -281,19 +281,24 @@ export function buildTauriBundleCommand(
   hostPlatform: NodeJS.Platform = process.platform
 ): TauriBundleCommand {
   const pnpmCommand = getShellSafePackageManagerCommand('pnpm', hostPlatform);
+  const args = [
+    'exec',
+    'tauri',
+    'build',
+    '--config',
+    tauriConfigRelativePath,
+    '--bundles',
+    releaseArtifactDefinitions[platform].bundleTarget,
+    '--ci'
+  ];
+
+  if (platform === 'linux') {
+    args.push('--verbose');
+  }
 
   return {
     command: pnpmCommand.command,
-    args: [
-      'exec',
-      'tauri',
-      'build',
-      '--config',
-      tauriConfigRelativePath,
-      '--bundles',
-      releaseArtifactDefinitions[platform].bundleTarget,
-      '--ci'
-    ],
+    args,
     shell: pnpmCommand.shell
   };
 }


### PR DESCRIPTION
## Summary
- Fixes the current main Desktop Release failure where Linux AppImage bundling fails in linuxdeploy and blocks `publish-release`.
- Adds Linux runner AppImage/linuxdeploy dependencies and command preflight checks.
- Makes Linux Tauri bundling verbose so linuxdeploy failures show actionable logs if the runner still fails.

## Verification
- `pnpm vitest run tools/scripts/tauri/release/release.spec.ts`
- `git diff --check`
- `pnpm review:plan`
- `pnpm review:test`
- `pnpm review:implementation`
- Commit hook completed successfully, including `lint-staged` and the repo precommit coverage suite.

## CI Context
Latest main failure before this fix: https://github.com/WodenWang820118/tag-check/actions/runs/25619729844

The release gate succeeded in that run. Linux AppImage bundling failed, which made `publish-release` skip and prevented the draft release from appearing.