### PR TITLE
fix: prune Linux AppImage prebuilds

### DIFF
--- a/tools/scripts/tauri/release/release.spec.ts
+++ b/tools/scripts/tauri/release/release.spec.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import {
+  existsSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -7,7 +8,7 @@ import {
   writeFileSync
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -20,6 +21,7 @@ import {
   buildTauriBundleCommand,
   createChecksumFileContents,
   parseStableReleaseTag,
+  pruneLinuxAppImageBackendPrebuilds,
   readVersionAuthorities,
   resolveReleasePlatform,
   validateReleaseArtifact,
@@ -68,6 +70,27 @@ function createFixtureDirectory() {
 
 function hashContent(content: string) {
   return createHash('sha256').update(content).digest('hex');
+}
+
+function writeBackendPrebuildFixture(
+  backendDirectory: string,
+  packageDirectory: string,
+  prebuildDirectories: string[]
+) {
+  const prebuildsDirectory = join(
+    backendDirectory,
+    'node_modules',
+    packageDirectory,
+    'prebuilds'
+  );
+
+  for (const prebuildDirectory of prebuildDirectories) {
+    const directory = join(prebuildsDirectory, prebuildDirectory);
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(join(directory, 'native.node'), 'native binary fixture');
+  }
+
+  return prebuildsDirectory;
 }
 
 function createReleaseManifest(
@@ -209,6 +232,80 @@ describe('release helper', () => {
       ],
       shell: true
     });
+  });
+
+  it('prunes non-linux-x64 backend native prebuilds before AppImage bundling', () => {
+    const backendDirectory = createFixtureDirectory();
+    const bareFsPrebuildsDirectory = writeBackendPrebuildFixture(
+      backendDirectory,
+      'bare-fs',
+      [
+        'android-x64',
+        'darwin-arm64',
+        'linux-arm64',
+        'linux-x64',
+        'linux-x64-glibc',
+        'linux-x64-gnu',
+        'linux-x64-musl',
+        'win32-x64'
+      ]
+    );
+    const scopedPrebuildsDirectory = writeBackendPrebuildFixture(
+      backendDirectory,
+      join('@scope', 'native-runtime'),
+      ['linux-x64', 'linux-arm64']
+    );
+
+    const removedDirectories = pruneLinuxAppImageBackendPrebuilds(
+      backendDirectory
+    ).map((directory) => relative(backendDirectory, directory));
+
+    expect(existsSync(join(bareFsPrebuildsDirectory, 'linux-x64'))).toBe(true);
+    expect(existsSync(join(bareFsPrebuildsDirectory, 'linux-x64-glibc'))).toBe(
+      true
+    );
+    expect(existsSync(join(bareFsPrebuildsDirectory, 'linux-x64-gnu'))).toBe(
+      true
+    );
+    expect(existsSync(join(scopedPrebuildsDirectory, 'linux-x64'))).toBe(true);
+    expect(existsSync(join(bareFsPrebuildsDirectory, 'android-x64'))).toBe(
+      false
+    );
+    expect(existsSync(join(bareFsPrebuildsDirectory, 'darwin-arm64'))).toBe(
+      false
+    );
+    expect(existsSync(join(bareFsPrebuildsDirectory, 'linux-arm64'))).toBe(
+      false
+    );
+    expect(existsSync(join(bareFsPrebuildsDirectory, 'linux-x64-musl'))).toBe(
+      false
+    );
+    expect(existsSync(join(bareFsPrebuildsDirectory, 'win32-x64'))).toBe(false);
+    expect(existsSync(join(scopedPrebuildsDirectory, 'linux-arm64'))).toBe(
+      false
+    );
+    expect(removedDirectories).toEqual(
+      expect.arrayContaining([
+        join('node_modules', 'bare-fs', 'prebuilds', 'android-x64'),
+        join('node_modules', 'bare-fs', 'prebuilds', 'darwin-arm64'),
+        join('node_modules', 'bare-fs', 'prebuilds', 'linux-arm64'),
+        join('node_modules', 'bare-fs', 'prebuilds', 'linux-x64-musl'),
+        join('node_modules', 'bare-fs', 'prebuilds', 'win32-x64'),
+        join(
+          'node_modules',
+          '@scope',
+          'native-runtime',
+          'prebuilds',
+          'linux-arm64'
+        )
+      ])
+    );
+  });
+
+  it('treats missing backend node_modules as a no-op when pruning prebuilds', () => {
+    expect(
+      pruneLinuxAppImageBackendPrebuilds(createFixtureDirectory())
+    ).toEqual([]);
   });
 
   it('formats checksum files in release order', () => {

--- a/tools/scripts/tauri/release/release.ts
+++ b/tools/scripts/tauri/release/release.ts
@@ -12,7 +12,7 @@ import {
   statSync,
   writeFileSync
 } from 'node:fs';
-import { basename, dirname, join } from 'node:path';
+import { basename, dirname, join, relative } from 'node:path';
 
 import archiver from 'archiver';
 
@@ -22,7 +22,10 @@ import {
 } from '../../shared/process.ts';
 import { isDirectEntrypoint } from '../../shared/paths.ts';
 import { getRustTargetTriple } from '../node-sidecar/node-sidecar.ts';
-import { workspaceRoot } from '../path-contract/path-contract.ts';
+import {
+  backendDistDir,
+  workspaceRoot
+} from '../path-contract/path-contract.ts';
 
 export type ReleasePlatform = 'windows' | 'macos' | 'linux';
 
@@ -162,6 +165,11 @@ const releaseManifestFileName = 'release-manifest.json';
 const tauriConfigRelativePath = 'apps/desktop-tauri/src-tauri/tauri.conf.json';
 const checksumFileName = 'SHA256SUMS.txt';
 const releasePlatformOrder: ReleasePlatform[] = ['windows', 'macos', 'linux'];
+const linuxAppImagePrebuildDirectories = new Set([
+  'linux-x64',
+  'linux-x64-glibc',
+  'linux-x64-gnu'
+]);
 
 function readJsonFile<T>(targetPath: string): T {
   return JSON.parse(readFileSync(targetPath, 'utf8')) as T;
@@ -332,6 +340,68 @@ function removeAndRecreateDirectory(targetPath: string) {
 
 function ensureDirectory(targetPath: string) {
   mkdirSync(targetPath, { recursive: true });
+}
+
+function isLinuxAppImagePrebuildDirectory(directoryName: string) {
+  return linuxAppImagePrebuildDirectories.has(directoryName);
+}
+
+function collectNativePrebuildDirectories(searchRoot: string) {
+  if (!existsSync(searchRoot)) {
+    return [];
+  }
+
+  const prebuildDirectories: string[] = [];
+
+  for (const entry of readdirSync(searchRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const entryPath = join(searchRoot, entry.name);
+
+    if (entry.name === 'prebuilds') {
+      prebuildDirectories.push(entryPath);
+      continue;
+    }
+
+    prebuildDirectories.push(...collectNativePrebuildDirectories(entryPath));
+  }
+
+  return prebuildDirectories;
+}
+
+export function pruneLinuxAppImageBackendPrebuilds(
+  backendDirectory = backendDistDir
+) {
+  const nodeModulesDirectory = join(backendDirectory, 'node_modules');
+
+  if (!existsSync(nodeModulesDirectory)) {
+    return [];
+  }
+
+  const removedDirectories: string[] = [];
+
+  for (const prebuildDirectory of collectNativePrebuildDirectories(
+    nodeModulesDirectory
+  )) {
+    for (const entry of readdirSync(prebuildDirectory, {
+      withFileTypes: true
+    })) {
+      if (
+        !entry.isDirectory() ||
+        isLinuxAppImagePrebuildDirectory(entry.name)
+      ) {
+        continue;
+      }
+
+      const entryPath = join(prebuildDirectory, entry.name);
+      rmSync(entryPath, { force: true, recursive: true });
+      removedDirectories.push(entryPath);
+    }
+  }
+
+  return removedDirectories;
 }
 
 function getArgumentValue(flag: string, args: string[]) {
@@ -696,6 +766,25 @@ async function bundleReleaseArtifact(args: string[]) {
 
   const releaseDirectory = resolveReleaseDirectory(platform);
   removeAndRecreateDirectory(releaseDirectory);
+
+  if (platform === 'linux') {
+    const removedPrebuildDirectories = pruneLinuxAppImageBackendPrebuilds();
+
+    if (removedPrebuildDirectories.length > 0) {
+      console.log(
+        `Pruned ${removedPrebuildDirectories.length} non-Linux x64 GNU backend native prebuild directories before Linux AppImage bundling.`
+      );
+      for (const removedDirectory of removedPrebuildDirectories) {
+        console.log(
+          `Pruned backend native prebuild directory: ${relative(
+            backendDistDir,
+            removedDirectory
+          )}`
+        );
+      }
+    }
+  }
+
   const bundleCommand = buildTauriBundleCommand(platform);
 
   runSyncCommandOrThrow({


### PR DESCRIPTION
## Summary
- prune non-Linux x64 backend native prebuild directories before Linux AppImage bundling
- preserve linux-x64, linux-x64-glibc, and linux-x64-gnu prebuilds for the Linux runner
- add regression coverage for pruning behavior, scoped packages, and missing node_modules no-op

## Verification
- pnpm exec vitest run tools/scripts/tauri/release/release.spec.ts
- node tools/scripts/tauri/release/release.ts describe --platform linux --release-tag v2.0.0
- git diff --check
- pnpm review:test
- pnpm review:implementation
- pre-commit hook completed successfully during commit

## Release State
- gh release view v2.0.0 currently returns release not found
- gh release list shows no draft release yet
- expected until this fix reaches main and the Desktop Release workflow reaches publish-release
