### PR TITLE
fix: unblock desktop release build

### DIFF
--- a/libs/utils/src/lib/dtos/report-details.dto.ts
+++ b/libs/utils/src/lib/dtos/report-details.dto.ts
@@ -25,7 +25,7 @@ export class ReportDetailsDto implements OutputValidationResult {
   imageSize!: number;
   updatedAt?: Date;
 
-  constructor(report: Partial<OutputValidationResult>) {
+  constructor(report: Partial<ReportDetailsDto>) {
     Object.assign(this, report);
   }
 }

--- a/libs/utils/src/lib/functions/tag-build-contract.spec.ts
+++ b/libs/utils/src/lib/functions/tag-build-contract.spec.ts
@@ -119,7 +119,7 @@ describe('isParameter', () => {
     [undefined, 'undefined'],
     ['string', 'string'],
     [42, 'number']
-  ])('rejects non-records (%s)', (input) => {
+  ])('rejects non-records (%s)', (input, _label) => {
     expect(isParameter(input)).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- Fix ReportDetailsDto constructor typing so DTO-only fields such as position can be passed in tests and DTO construction.
- Fix the Vitest `it.each` callback signature in the tag-build contract spec.

## Verification
- `pnpm nx build nest-backend --skipNxCache`
- `pnpm exec vitest run libs/utils/src/lib/dtos/report-details.dto.spec.ts libs/utils/src/lib/functions/tag-build-contract.spec.ts`
- `pnpm nx run desktop-tauri:prepare-runtime --skipNxCache`

## Context
Main Desktop Release run `25624401582` failed in all OS matrix jobs because `desktop-tauri:prepare-runtime` hit TypeScript errors TS2353 and TS2345 while building `nest-backend`.