### PR TITLE
feat(ui): add mermaid diagram component and improve about/objectives layout

### DIFF
--- a/apps/ng-product-doc/project.json
+++ b/apps/ng-product-doc/project.json
@@ -55,6 +55,7 @@
         ],
         "styles": [
           "@angular/material/prebuilt-themes/indigo-pink.css",
+          "apps/ng-product-doc/src/tailwind.css",
           "apps/ng-product-doc/src/styles.scss",
           "apps/ng-tag-build/src/styles.scss",
           "libs/shared-styles/src/index.scss",

--- a/apps/ng-product-doc/src/tailwind.css
+++ b/apps/ng-product-doc/src/tailwind.css
@@ -1,0 +1,28 @@
+/* Tailwind v4 entrypoint for ng-product-doc.
+ *
+ * Kept as a pure CSS file (not .scss) so the @tailwindcss/postcss plugin
+ * processes the @import / @source directives directly. Sass would otherwise
+ * inline the @import statements before PostCSS could expand them, which
+ * suppressed all responsive variants (md:, lg:, xl:) in the compiled
+ * stylesheet.
+ *
+ * preflight is intentionally NOT imported because Angular Material's
+ * prebuilt indigo-pink theme plus libs/shared-styles already provide a
+ * full baseline; a global reset on top of those would visually regress
+ * existing components.
+ *
+ * Note: Material's component baselines (e.g. `.mat-mdc-icon-button
+ * { display: inline-block }`) are emitted unlayered by both
+ * @angular/material/prebuilt-themes and libs/shared-styles' SCSS
+ * `mat.all-component-themes` mixin. Per the CSS Cascade, unlayered rules
+ * outrank any @layer at equal specificity, so where a Tailwind utility
+ * needs to override a Material baseline (e.g. `lg:hidden` on a
+ * `mat-icon-button`) use the `!` important suffix in the template.
+ */
+@layer theme, base, components, utilities;
+
+@import 'tailwindcss/theme.css' layer(theme);
+@import 'tailwindcss/utilities.css' layer(utilities);
+
+@source "../../../libs/ui/src/**/*.{html,ts}";
+@source "../../../apps/ng-product-doc/src/**/*.{html,ts}";

--- a/apps/ng-tag-build/src/locale/messages.ja.xlf
+++ b/apps/ng-tag-build/src/locale/messages.ja.xlf
@@ -74,14 +74,6 @@
           <context context-type="linenumber">2,4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="about.diagram.alt" datatype="html">
-        <source>Tag Build System Diagram</source>
-        <target>Tag Build システム図</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">libs/ui/src/lib/components/about/about.component.html</context>
-          <context context-type="linenumber">7,11</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="about.description.main" datatype="html">
         <source> Tag Build is an innovative tool designed specifically for digital marketers and SEO professionals. It streamlines the process of generating JSON files for Google Tag Manager (GTM), following GA4&apos;s recommended event structure to ensure optimal tracking implementation. </source>
         <target>Tag Build は、デジタルマーケターとSEO専門家のために特別に設計された革新的なツールです。Google Tag Manager (GTM)
@@ -154,6 +146,14 @@
           <context context-type="sourcefile">libs/ui/src/lib/components/about/about.component.html</context>
           <context context-type="linenumber">61,64</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="about.code.label.ga4" datatype="html">
+        <source>GA4 Event</source>
+        <target>GA4 イベント</target>
+      </trans-unit>
+      <trans-unit id="about.code.label.tagbuild" datatype="html">
+        <source>Tag Build</source>
+        <target>Tag Build 形式</target>
       </trans-unit>
       <trans-unit id="advancedExpansionPanelComponentAdditionalTagsVariables" datatype="html">
         <source> Additional Built-in Tags/variables </source>
@@ -670,14 +670,6 @@
           <context context-type="linenumber">4,6</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="objectives.diagram.alt" datatype="html">
-        <source>Diagram showing the Tag Check System architecture and workflow</source>
-        <target>タグチェックシステムのアーキテクチャとワークフローを示す図</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">libs/ui/src/lib/components/objectives/objectives.component.html</context>
-          <context context-type="linenumber">11,14</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="objectives.achievement.intro" datatype="html">
         <source> The GTM Tag Build provides a user-friendly interface for digital marketers and SEO experts to generate JSON files for Google Tag Manager. This tool streamlines tag management by: </source>
         <target>GTM タグビルドは、デジタルマーケターやSEO専門家向けに、Google Tag
@@ -871,6 +863,82 @@
           <context context-type="sourcefile">libs/ui/src/lib/modules/documentation/tree-data.ts</context>
           <context context-type="linenumber">59</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="diagram.node.specification" datatype="html">
+        <source>Specification</source>
+        <target>仕様</target>
+      </trans-unit>
+      <trans-unit id="diagram.node.ga4events" datatype="html">
+        <source>GA4 Events</source>
+        <target>GA4イベント</target>
+      </trans-unit>
+      <trans-unit id="diagram.node.gtmdocs" datatype="html">
+        <source>GTM Docs</source>
+        <target>GTMドキュメント</target>
+      </trans-unit>
+      <trans-unit id="diagram.node.website" datatype="html">
+        <source>website</source>
+        <target>ウェブサイト</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.outputs-json" datatype="html">
+        <source>Outputs JSON</source>
+        <target>JSONを出力</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.validates" datatype="html">
+        <source>validates</source>
+        <target>検証</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.reports-issues" datatype="html">
+        <source>reports issues</source>
+        <target>問題を報告</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.defines-events" datatype="html">
+        <source>defines events</source>
+        <target>イベントを定義</target>
+      </trans-unit>
+      <trans-unit id="diagram.subgraph.sources" datatype="html">
+        <source>Sources</source>
+        <target>ソース</target>
+      </trans-unit>
+      <trans-unit id="diagram.subgraph.tag-build" datatype="html">
+        <source>Tag Build</source>
+        <target>Tag Build</target>
+      </trans-unit>
+      <trans-unit id="diagram.subgraph.tag-check" datatype="html">
+        <source>Tag Check</source>
+        <target>Tag Check</target>
+      </trans-unit>
+      <trans-unit id="diagram.aria.tag-build" datatype="html">
+        <source>Tag Build workflow: GA4 Events and GTM Docs feed into Specification and TagBuild to produce GTM output</source>
+        <target>Tag Buildワークフロー：GA4イベントとGTMドキュメントが仕様とTagBuildに流れ、GTM出力を生成</target>
+      </trans-unit>
+      <trans-unit id="diagram.aria.tag-check" datatype="html">
+        <source>Tag Check workflow: TagBuild outputs GTM JSON that runs on the website; TagCheck monitors GTM and the website against the Specification to surface issues</source>
+        <target>Tag Checkワークフロー：TagBuildがウェブサイト上で動作するGTM JSONを出力；TagCheckは仙5様に基づきGTMとウェブサイトを監視し問題を報告</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.runs-on" datatype="html">
+        <source>runs on</source>
+        <target>上で動作</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.monitors" datatype="html">
+        <source>monitors</source>
+        <target>監視</target>
+      </trans-unit>
+      <trans-unit id="diagram.caption.tag-build" datatype="html">
+        <source>Fig. 1 — Tag Build workflow</source>
+        <target>図1 — Tag Buildワークフロー</target>
+      </trans-unit>
+      <trans-unit id="diagram.caption.tag-check" datatype="html">
+        <source>Fig. 2 — Tag Check workflow</source>
+        <target>図2 — Tag Checkワークフロー</target>
+      </trans-unit>
+      <trans-unit id="mermaid.error.message" datatype="html">
+        <source>Failed to load diagram.</source>
+        <target>図の読み込みに失敗しました。</target>
+      </trans-unit>
+      <trans-unit id="mermaid.error.retry" datatype="html">
+        <source>Retry</source>
+        <target>再試行</target>
       </trans-unit>
     </body>
   </file>

--- a/apps/ng-tag-build/src/locale/messages.xlf
+++ b/apps/ng-tag-build/src/locale/messages.xlf
@@ -65,13 +65,6 @@
           <context context-type="linenumber">2,4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="about.diagram.alt" datatype="html">
-        <source>Tag Build System Diagram</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">libs/ui/src/lib/components/about/about.component.html</context>
-          <context context-type="linenumber">7,11</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="about.description.main" datatype="html">
         <source> Tag Build is an innovative tool designed specifically for digital marketers and SEO professionals. It streamlines the process of generating JSON files for Google Tag Manager (GTM), following GA4&apos;s recommended event structure to ensure optimal tracking implementation. </source>
         <context-group purpose="location">
@@ -129,6 +122,12 @@
           <context context-type="sourcefile">libs/ui/src/lib/components/about/about.component.html</context>
           <context context-type="linenumber">61,64</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="about.code.label.ga4" datatype="html">
+        <source>GA4 Event</source>
+      </trans-unit>
+      <trans-unit id="about.code.label.tagbuild" datatype="html">
+        <source>Tag Build</source>
       </trans-unit>
       <trans-unit id="advancedExpansionPanelComponentAdditionalTagsVariables" datatype="html">
         <source> Additional Built-in Tags/variables </source>
@@ -581,13 +580,6 @@
           <context context-type="linenumber">4,6</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="objectives.diagram.alt" datatype="html">
-        <source>Diagram showing the Tag Check System architecture and workflow</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">libs/ui/src/lib/components/objectives/objectives.component.html</context>
-          <context context-type="linenumber">11,14</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="objectives.achievement.intro" datatype="html">
         <source> The GTM Tag Build provides a user-friendly interface for digital marketers and SEO experts to generate JSON files for Google Tag Manager. This tool streamlines tag management by: </source>
         <context-group purpose="location">
@@ -755,6 +747,63 @@
           <context context-type="sourcefile">libs/ui/src/lib/modules/documentation/tree-data.ts</context>
           <context context-type="linenumber">59</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="diagram.node.specification" datatype="html">
+        <source>Specification</source>
+      </trans-unit>
+      <trans-unit id="diagram.node.ga4events" datatype="html">
+        <source>GA4 Events</source>
+      </trans-unit>
+      <trans-unit id="diagram.node.gtmdocs" datatype="html">
+        <source>GTM Docs</source>
+      </trans-unit>
+      <trans-unit id="diagram.node.website" datatype="html">
+        <source>website</source>
+      </trans-unit>
+      <trans-unit id="diagram.edge.outputs-json" datatype="html">
+        <source>Outputs JSON</source>
+      </trans-unit>
+      <trans-unit id="diagram.edge.validates" datatype="html">
+        <source>validates</source>
+      </trans-unit>
+      <trans-unit id="diagram.edge.reports-issues" datatype="html">
+        <source>reports issues</source>
+      </trans-unit>
+      <trans-unit id="diagram.edge.defines-events" datatype="html">
+        <source>defines events</source>
+      </trans-unit>
+      <trans-unit id="diagram.subgraph.sources" datatype="html">
+        <source>Sources</source>
+      </trans-unit>
+      <trans-unit id="diagram.subgraph.tag-build" datatype="html">
+        <source>Tag Build</source>
+      </trans-unit>
+      <trans-unit id="diagram.subgraph.tag-check" datatype="html">
+        <source>Tag Check</source>
+      </trans-unit>
+      <trans-unit id="diagram.aria.tag-build" datatype="html">
+        <source>Tag Build workflow: GA4 Events and GTM Docs feed into Specification and TagBuild to produce GTM output</source>
+      </trans-unit>
+      <trans-unit id="diagram.aria.tag-check" datatype="html">
+        <source>Tag Check workflow: TagBuild outputs GTM JSON that runs on the website; TagCheck monitors GTM and the website against the Specification to surface issues</source>
+      </trans-unit>
+      <trans-unit id="diagram.edge.runs-on" datatype="html">
+        <source>runs on</source>
+      </trans-unit>
+      <trans-unit id="diagram.edge.monitors" datatype="html">
+        <source>monitors</source>
+      </trans-unit>
+      <trans-unit id="diagram.caption.tag-build" datatype="html">
+        <source>Fig. 1 — Tag Build workflow</source>
+      </trans-unit>
+      <trans-unit id="diagram.caption.tag-check" datatype="html">
+        <source>Fig. 2 — Tag Check workflow</source>
+      </trans-unit>
+      <trans-unit id="mermaid.error.message" datatype="html">
+        <source>Failed to load diagram.</source>
+      </trans-unit>
+      <trans-unit id="mermaid.error.retry" datatype="html">
+        <source>Retry</source>
       </trans-unit>
     </body>
   </file>

--- a/apps/ng-tag-build/src/locale/messages.zh-hans.xlf
+++ b/apps/ng-tag-build/src/locale/messages.zh-hans.xlf
@@ -74,14 +74,6 @@
           <context context-type="linenumber">2,4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="about.diagram.alt" datatype="html">
-        <source>Tag Build System Diagram</source>
-        <target>Tag Build 系统图表</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">libs/ui/src/lib/components/about/about.component.html</context>
-          <context context-type="linenumber">7,11</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="about.description.main" datatype="html">
         <source> Tag Build is an innovative tool designed specifically for digital marketers and SEO professionals. It streamlines the process of generating JSON files for Google Tag Manager (GTM), following GA4&apos;s recommended event structure to ensure optimal tracking implementation. </source>
         <target>Tag Build 是一款专为数字营销人员和 SEO 专业人士设计的创新工具。它简化了为 Google Tag Manager (GTM) 生成 JSON
@@ -150,6 +142,14 @@
           <context context-type="sourcefile">libs/ui/src/lib/components/about/about.component.html</context>
           <context context-type="linenumber">61,64</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="about.code.label.ga4" datatype="html">
+        <source>GA4 Event</source>
+        <target>GA4 事件</target>
+      </trans-unit>
+      <trans-unit id="about.code.label.tagbuild" datatype="html">
+        <source>Tag Build</source>
+        <target>Tag Build 格式</target>
       </trans-unit>
       <trans-unit id="advancedExpansionPanelComponentAdditionalTagsVariables" datatype="html">
         <source> Additional Built-in Tags/variables </source>
@@ -665,14 +665,6 @@
           <context context-type="linenumber">4,6</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="objectives.diagram.alt" datatype="html">
-        <source>Diagram showing the Tag Check System architecture and workflow</source>
-        <target>展示标签检查系统架构和工作流程的图表</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">libs/ui/src/lib/components/objectives/objectives.component.html</context>
-          <context context-type="linenumber">11,14</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="objectives.achievement.intro" datatype="html">
         <source> The GTM Tag Build provides a user-friendly interface for digital marketers and SEO experts to generate JSON files for Google Tag Manager. This tool streamlines tag management by: </source>
         <target>GTM 标签构建工具为数字营销人员和 SEO 专家提供了一个友好的界面，用于生成 Google Tag Manager 的 JSON
@@ -865,6 +857,82 @@
           <context context-type="sourcefile">libs/ui/src/lib/modules/documentation/tree-data.ts</context>
           <context context-type="linenumber">59</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="diagram.node.specification" datatype="html">
+        <source>Specification</source>
+        <target>规范</target>
+      </trans-unit>
+      <trans-unit id="diagram.node.ga4events" datatype="html">
+        <source>GA4 Events</source>
+        <target>GA4 事件</target>
+      </trans-unit>
+      <trans-unit id="diagram.node.gtmdocs" datatype="html">
+        <source>GTM Docs</source>
+        <target>GTM 文档</target>
+      </trans-unit>
+      <trans-unit id="diagram.node.website" datatype="html">
+        <source>website</source>
+        <target>网站</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.outputs-json" datatype="html">
+        <source>Outputs JSON</source>
+        <target>输出 JSON</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.validates" datatype="html">
+        <source>validates</source>
+        <target>验证</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.reports-issues" datatype="html">
+        <source>reports issues</source>
+        <target>反馈问题</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.defines-events" datatype="html">
+        <source>defines events</source>
+        <target>定义事件</target>
+      </trans-unit>
+      <trans-unit id="diagram.subgraph.sources" datatype="html">
+        <source>Sources</source>
+        <target>数据来源</target>
+      </trans-unit>
+      <trans-unit id="diagram.subgraph.tag-build" datatype="html">
+        <source>Tag Build</source>
+        <target>Tag Build</target>
+      </trans-unit>
+      <trans-unit id="diagram.subgraph.tag-check" datatype="html">
+        <source>Tag Check</source>
+        <target>Tag Check</target>
+      </trans-unit>
+      <trans-unit id="diagram.aria.tag-build" datatype="html">
+        <source>Tag Build workflow: GA4 Events and GTM Docs feed into Specification and TagBuild to produce GTM output</source>
+        <target>Tag Build 工作流程：GA4 事件与 GTM 文档流入规范与 TagBuild，产出 GTM 输出</target>
+      </trans-unit>
+      <trans-unit id="diagram.aria.tag-check" datatype="html">
+        <source>Tag Check workflow: TagBuild outputs GTM JSON that runs on the website; TagCheck monitors GTM and the website against the Specification to surface issues</source>
+        <target>Tag Check 工作流程：TagBuild 输出运行于网站的 GTM JSON；TagCheck 依规范监控 GTM 与网站并反馈问题</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.runs-on" datatype="html">
+        <source>runs on</source>
+        <target>运行于</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.monitors" datatype="html">
+        <source>monitors</source>
+        <target>监控</target>
+      </trans-unit>
+      <trans-unit id="diagram.caption.tag-build" datatype="html">
+        <source>Fig. 1 — Tag Build workflow</source>
+        <target>图1 — Tag Build 工作流程</target>
+      </trans-unit>
+      <trans-unit id="diagram.caption.tag-check" datatype="html">
+        <source>Fig. 2 — Tag Check workflow</source>
+        <target>图2 — Tag Check 工作流程</target>
+      </trans-unit>
+      <trans-unit id="mermaid.error.message" datatype="html">
+        <source>Failed to load diagram.</source>
+        <target>图表加载失败。</target>
+      </trans-unit>
+      <trans-unit id="mermaid.error.retry" datatype="html">
+        <source>Retry</source>
+        <target>重试</target>
       </trans-unit>
     </body>
   </file>

--- a/apps/ng-tag-build/src/locale/messages.zh-hant.xlf
+++ b/apps/ng-tag-build/src/locale/messages.zh-hant.xlf
@@ -74,14 +74,6 @@
           <context context-type="linenumber">2,4</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="about.diagram.alt" datatype="html">
-        <source>Tag Build System Diagram</source>
-        <target>Tag Build 系統圖表</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">libs/ui/src/lib/components/about/about.component.html</context>
-          <context context-type="linenumber">7,11</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="about.description.main" datatype="html">
         <source> Tag Build is an innovative tool designed specifically for digital marketers and SEO professionals. It streamlines the process of generating JSON files for Google Tag Manager (GTM), following GA4&apos;s recommended event structure to ensure optimal tracking implementation. </source>
         <target>Tag Build 是一款專為數位行銷人員和 SEO 專業人士設計的創新工具。它簡化了為 Google Tag Manager (GTM) 生成 JSON
@@ -150,6 +142,14 @@
           <context context-type="sourcefile">libs/ui/src/lib/components/about/about.component.html</context>
           <context context-type="linenumber">61,64</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="about.code.label.ga4" datatype="html">
+        <source>GA4 Event</source>
+        <target>GA4 事件</target>
+      </trans-unit>
+      <trans-unit id="about.code.label.tagbuild" datatype="html">
+        <source>Tag Build</source>
+        <target>Tag Build 格式</target>
       </trans-unit>
       <trans-unit id="advancedExpansionPanelComponentAdditionalTagsVariables" datatype="html">
         <source> Additional Built-in Tags/variables </source>
@@ -665,14 +665,6 @@
           <context context-type="linenumber">4,6</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="objectives.diagram.alt" datatype="html">
-        <source>Diagram showing the Tag Check System architecture and workflow</source>
-        <target>展示標籤檢查系統架構和工作流程的圖表</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">libs/ui/src/lib/components/objectives/objectives.component.html</context>
-          <context context-type="linenumber">11,14</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="objectives.achievement.intro" datatype="html">
         <source> The GTM Tag Build provides a user-friendly interface for digital marketers and SEO experts to generate JSON files for Google Tag Manager. This tool streamlines tag management by: </source>
         <target>GTM 標籤建構工具為數位行銷人員和 SEO 專家提供了一個友善的介面，用於生成 Google Tag Manager 的 JSON
@@ -865,6 +857,82 @@
           <context context-type="sourcefile">libs/ui/src/lib/modules/documentation/tree-data.ts</context>
           <context context-type="linenumber">59</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="diagram.node.specification" datatype="html">
+        <source>Specification</source>
+        <target>規範</target>
+      </trans-unit>
+      <trans-unit id="diagram.node.ga4events" datatype="html">
+        <source>GA4 Events</source>
+        <target>GA4 事件</target>
+      </trans-unit>
+      <trans-unit id="diagram.node.gtmdocs" datatype="html">
+        <source>GTM Docs</source>
+        <target>GTM 文件</target>
+      </trans-unit>
+      <trans-unit id="diagram.node.website" datatype="html">
+        <source>website</source>
+        <target>網站</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.outputs-json" datatype="html">
+        <source>Outputs JSON</source>
+        <target>輸出 JSON</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.validates" datatype="html">
+        <source>validates</source>
+        <target>驗證</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.reports-issues" datatype="html">
+        <source>reports issues</source>
+        <target>回報問題</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.defines-events" datatype="html">
+        <source>defines events</source>
+        <target>定義事件</target>
+      </trans-unit>
+      <trans-unit id="diagram.subgraph.sources" datatype="html">
+        <source>Sources</source>
+        <target>資料來源</target>
+      </trans-unit>
+      <trans-unit id="diagram.subgraph.tag-build" datatype="html">
+        <source>Tag Build</source>
+        <target>Tag Build</target>
+      </trans-unit>
+      <trans-unit id="diagram.subgraph.tag-check" datatype="html">
+        <source>Tag Check</source>
+        <target>Tag Check</target>
+      </trans-unit>
+      <trans-unit id="diagram.aria.tag-build" datatype="html">
+        <source>Tag Build workflow: GA4 Events and GTM Docs feed into Specification and TagBuild to produce GTM output</source>
+        <target>Tag Build 工作流程：GA4 事件與 GTM 文件流入規範與 TagBuild，產出 GTM 輸出</target>
+      </trans-unit>
+      <trans-unit id="diagram.aria.tag-check" datatype="html">
+        <source>Tag Check workflow: TagBuild outputs GTM JSON that runs on the website; TagCheck monitors GTM and the website against the Specification to surface issues</source>
+        <target>Tag Check 工作流程：TagBuild 輸出運行於網站的 GTM JSON；TagCheck 依規範監測 GTM 與網站並回報問題</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.runs-on" datatype="html">
+        <source>runs on</source>
+        <target>運行於</target>
+      </trans-unit>
+      <trans-unit id="diagram.edge.monitors" datatype="html">
+        <source>monitors</source>
+        <target>監控</target>
+      </trans-unit>
+      <trans-unit id="diagram.caption.tag-build" datatype="html">
+        <source>Fig. 1 — Tag Build workflow</source>
+        <target>圖1 — Tag Build 工作流程</target>
+      </trans-unit>
+      <trans-unit id="diagram.caption.tag-check" datatype="html">
+        <source>Fig. 2 — Tag Check workflow</source>
+        <target>圖2 — Tag Check 工作流程</target>
+      </trans-unit>
+      <trans-unit id="mermaid.error.message" datatype="html">
+        <source>Failed to load diagram.</source>
+        <target>圖表載入失敗。</target>
+      </trans-unit>
+      <trans-unit id="mermaid.error.retry" datatype="html">
+        <source>Retry</source>
+        <target>重試</target>
       </trans-unit>
     </body>
   </file>

--- a/libs/shared-styles/src/styles/_variables.scss
+++ b/libs/shared-styles/src/styles/_variables.scss
@@ -24,3 +24,7 @@ $content-max: 1024px;
 // Fluid spacing tokens
 $space-gutter: clamp(1rem, 2vw, 2rem);
 $space-block: clamp(1.5rem, 3vw, 3rem);
+
+// Reading content typography tokens (base: html { font-size: 62.5% } → 1rem = 10px)
+$font-size-body-read: 1.7rem; // 17px — long-form reading paragraphs
+$font-size-caption: 1.4rem; // 14px — captions, secondary UI text

--- a/libs/ui/src/lib/components/about/about.component.html
+++ b/libs/ui/src/lib/components/about/about.component.html
@@ -1,70 +1,96 @@
 <div class="about">
   <h1 class="about__title" i18n="@@about.title">Understanding Tag Build</h1>
-  <img
-    class="about__diagram"
-    [src]="getLocalizedSvgPath()"
-    i18n-alt="@@about.diagram.alt"
-    alt="Tag Build System Diagram"
-  />
+  <div class="about__layout">
+    <div class="about__text">
+      <p
+        class="about__description"
+        i18n="Description of Tag Build@@about.description.main"
+      >
+        Tag Build is an innovative tool designed specifically for digital
+        marketers and SEO professionals. It streamlines the process of
+        generating JSON files for Google Tag Manager (GTM), following GA4's
+        recommended event structure to ensure optimal tracking implementation.
+      </p>
 
-  <p
-    class="about__description"
-    i18n="Description of Tag Build@@about.description.main"
-  >
-    Tag Build is an innovative tool designed specifically for digital marketers
-    and SEO professionals. It streamlines the process of generating JSON files
-    for Google Tag Manager (GTM), following GA4's recommended event structure to
-    ensure optimal tracking implementation.
-  </p>
+      <p
+        class="about__description"
+        i18n="Description of GTM challenges@@about.description.challenges"
+      >
+        While Google Tag Manager offers basic functionality for implementing GA4
+        events, the rapidly evolving nature of business and marketing
+        requirements often necessitates frequent updates and validation. Tag
+        Build addresses these challenges by providing a more efficient and
+        maintainable solution.
+      </p>
 
-  <p
-    class="about__description"
-    i18n="Description of GTM challenges@@about.description.challenges"
-  >
-    While Google Tag Manager offers basic functionality for implementing GA4
-    events, the rapidly evolving nature of business and marketing requirements
-    often necessitates frequent updates and validation. Tag Build addresses
-    these challenges by providing a more efficient and maintainable solution.
-  </p>
+      <section class="about__section">
+        <h1 class="about__section-title" i18n="@@about.section.why.title">
+          Why Tag Build?
+        </h1>
+        <div class="about__section-content" i18n="@@about.section.why.content">
+          Traditional implementation methods using Google Cloud Platform (GCP)
+          servers can synchronize Google Sheets with GTM effectively. However,
+          many marketing agencies lack access to GCP resources, creating a need
+          for a more accessible solution. Tag Build bridges this gap by
+          providing a standalone tool that doesn't require complex
+          infrastructure.
+        </div>
+      </section>
 
-  <section class="about__section">
-    <h1 class="about__section-title" i18n="@@about.section.why.title">
-      Why Tag Build?
-    </h1>
-    <div class="about__section-content" i18n="@@about.section.why.content">
-      Traditional implementation methods using Google Cloud Platform (GCP)
-      servers can synchronize Google Sheets with GTM effectively. However, many
-      marketing agencies lack access to GCP resources, creating a need for a
-      more accessible solution. Tag Build bridges this gap by providing a
-      standalone tool that doesn't require complex infrastructure.
+      <section class="about__section">
+        <h1 class="about__section-title" i18n="@@about.section.benefits.title">
+          Who Benefits?
+        </h1>
+        <div
+          class="about__section-content"
+          i18n="@@about.section.benefits.content"
+        >
+          Tag Build is ideal for marketing professionals who want to streamline
+          their workflow and focus more on data analytics and business
+          intelligence. It's particularly valuable for teams looking to optimize
+          their tracking implementation while maintaining efficiency.
+        </div>
+      </section>
     </div>
-  </section>
 
-  <section class="about__section">
-    <h1 class="about__section-title" i18n="@@about.section.benefits.title">
-      Who Benefits?
-    </h1>
-    <div class="about__section-content" i18n="@@about.section.benefits.content">
-      Tag Build is ideal for marketing professionals who want to streamline
-      their workflow and focus more on data analytics and business intelligence.
-      It's particularly valuable for teams looking to optimize their tracking
-      implementation while maintaining efficiency.
-    </div>
-  </section>
+    <figure class="about__diagram">
+      <lib-mermaid-diagram
+        [diagramDef]="tagBuildDiagram"
+        [ariaLabel]="tagBuildDiagramLabel"
+      />
+      <figcaption
+        class="about__diagram-caption"
+        i18n="@@diagram.caption.tag-build"
+      >
+        Fig. 1 — Tag Build workflow
+      </figcaption>
+    </figure>
+  </div>
 
-  <section class="about__section">
+  <section class="about__howworks">
     <h1 class="about__section-title" i18n="@@about.section.howworks.title">
       How It Works
     </h1>
-    <div class="about__section-content">
-      <span i18n="@@about.section.howworks.intro">
-        Explore the seamless integration between GA4 recommended events and Tag
-        Build's structured format:
-      </span>
-      <div class="about__code-container">
+    <p class="about__howworks-intro" i18n="@@about.section.howworks.intro">
+      Explore the seamless integration between GA4 recommended events and Tag
+      Build's structured format:
+    </p>
+    <div class="about__code-container">
+      <figure class="about__code-block">
+        <figcaption class="about__code-label" i18n="@@about.code.label.ga4">
+          GA4 Event
+        </figcaption>
         <pre class="about__code">{{ exampleInput | json }}</pre>
+      </figure>
+      <figure class="about__code-block">
+        <figcaption
+          class="about__code-label"
+          i18n="@@about.code.label.tagbuild"
+        >
+          Tag Build
+        </figcaption>
         <pre class="about__code">{{ exampleArrayInput | json }}</pre>
-      </div>
+      </figure>
     </div>
   </section>
 </div>

--- a/libs/ui/src/lib/components/about/about.component.scss
+++ b/libs/ui/src/lib/components/about/about.component.scss
@@ -1,59 +1,109 @@
 @use 'libs/shared-styles/src/variables.scss' as *;
 
 .about {
-  max-width: $content-max;
+  max-width: 1200px;
   margin: 0 auto;
-  padding-inline: $space-gutter;
+  padding-inline: clamp(2rem, 5vw, 4rem);
   overflow: hidden;
 
+  &__layout {
+    display: grid;
+    grid-template-columns: 1fr min(42rem, 46%);
+    gap: 2.5rem;
+    align-items: start;
+  }
+
   &__diagram {
-    float: right;
-    max-width: min(63%, 36rem);
-    margin: 0 0 1rem 1.25rem;
-    border-radius: 5px;
-    height: auto;
+    position: sticky;
+    top: 2rem;
+  }
+
+  &__diagram-caption {
+    margin-top: 0.5rem;
+    font-size: $font-size-caption;
+    color: var(--color-text-muted, #666);
+    text-align: center;
   }
 
   &__description {
     margin-bottom: 1rem;
-    line-height: 1.6;
+    font-size: $font-size-body-read;
+    line-height: 1.7;
     text-align: justify;
     text-justify: inter-word;
   }
 
   &__section-content {
     margin-bottom: 1rem;
+    font-size: $font-size-body-read;
+    line-height: 1.7;
   }
 
   &__code-container {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
-    gap: clamp(1rem, 3vw, 5rem);
+    gap: 2rem;
+    align-items: stretch;
+  }
+
+  &__code-block {
+    flex: 1 1 0;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+  }
+
+  &__code-label {
+    font-size: $font-size-caption;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+    color: #333;
   }
 
   &__code {
+    flex: 1;
     background-color: #f4f4f4;
     border: 1px solid #ddd;
     border-radius: 4px;
-    padding: 10px;
+    padding: 1rem 1.2rem;
     font-family: monospace;
-    overflow: auto;
-    max-width: 100%;
+    font-size: 1.3rem;
+    line-height: 1.6;
+    overflow-x: auto;
+    white-space: pre;
+    margin: 0;
   }
 
-  // Below the laptop breakpoint the floated diagram crowds the text;
-  // unfloat and stack so paragraphs stay readable on tablet portrait.
+  &__howworks {
+    margin-top: 2.5rem;
+    padding-top: 2rem;
+    border-top: 1px solid #eee;
+  }
+
+  &__howworks-intro {
+    font-size: $font-size-body-read;
+    line-height: 1.7;
+    margin-bottom: 1.5rem;
+  }
+
   @media (max-width: ($bp-laptop - 1)) {
+    &__layout {
+      grid-template-columns: 1fr;
+    }
+
     &__diagram {
-      float: none;
-      max-width: 100%;
-      margin: 1rem 0;
-      display: block;
+      position: static;
     }
 
     &__description {
       text-align: left;
+    }
+  }
+
+  @media (max-width: ($bp-pad - 1)) {
+    &__code-container {
+      flex-direction: column;
     }
   }
 }

--- a/libs/ui/src/lib/components/about/about.component.spec.ts
+++ b/libs/ui/src/lib/components/about/about.component.spec.ts
@@ -1,4 +1,3 @@
-import { LOCALE_ID } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -8,10 +7,7 @@ describe('AboutComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AboutComponent],
-      providers: [
-        { provide: LOCALE_ID, useValue: 'en' },
-        provideNoopAnimations()
-      ]
+      providers: [provideNoopAnimations()]
     }).compileComponents();
   });
 
@@ -21,23 +17,19 @@ describe('AboutComponent', () => {
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('builds a localized SVG path from the active locale', () => {
+  it('builds a mermaid diagram definition containing the key nodes', () => {
     const fixture = TestBed.createComponent(AboutComponent);
-    expect(fixture.componentInstance.getLocalizedSvgPath()).toBe(
-      '/assets/i18n/en/tag_build_system_en.drawio.svg'
-    );
+    const diagram = fixture.componentInstance.tagBuildDiagram;
+    expect(diagram).toContain('flowchart TD');
+    expect(diagram).toContain('TagBuild');
+    expect(diagram).toContain('GTM');
   });
 
-  it('uses the configured locale token', () => {
-    TestBed.resetTestingModule();
-    TestBed.configureTestingModule({
-      imports: [AboutComponent],
-      providers: [{ provide: LOCALE_ID, useValue: 'ja' }]
-    });
+  it('exposes a non-empty aria label for the diagram', () => {
     const fixture = TestBed.createComponent(AboutComponent);
-    expect(fixture.componentInstance.getLocalizedSvgPath()).toBe(
-      '/assets/i18n/ja/tag_build_system_ja.drawio.svg'
-    );
+    expect(
+      fixture.componentInstance.tagBuildDiagramLabel.length
+    ).toBeGreaterThan(0);
   });
 
   it('exposes example payloads with the expected shape', () => {

--- a/libs/ui/src/lib/components/about/about.component.ts
+++ b/libs/ui/src/lib/components/about/about.component.ts
@@ -1,15 +1,18 @@
 import { JsonPipe } from '@angular/common';
-import { Component, Inject, LOCALE_ID } from '@angular/core';
-import { getLocaleConfig } from '../../locale/locale-routing';
+import { Component } from '@angular/core';
+import { MermaidDiagramComponent } from '../mermaid-diagram/mermaid-diagram.component';
 
 @Component({
   selector: 'lib-about',
   standalone: true,
-  imports: [JsonPipe],
+  imports: [JsonPipe, MermaidDiagramComponent],
   templateUrl: './about.component.html',
   styleUrls: ['./about.component.scss']
 })
 export class AboutComponent {
+  readonly tagBuildDiagram = this.buildTagBuildDiagram();
+  readonly tagBuildDiagramLabel = $localize`:@@diagram.aria.tag-build:Tag Build workflow: GA4 Events and GTM Docs feed into Specification and TagBuild to produce GTM output`;
+
   exampleInput = {
     comments: '----- usual event data -----',
     event: 'begin_checkout',
@@ -44,10 +47,28 @@ export class AboutComponent {
     this.exampleInput
   ];
 
-  constructor(@Inject(LOCALE_ID) private readonly locale: string) {}
+  private buildTagBuildDiagram(): string {
+    const spec = $localize`:@@diagram.node.specification:Specification`;
+    const ga4 = $localize`:@@diagram.node.ga4events:GA4 Events`;
+    const docs = $localize`:@@diagram.node.gtmdocs:GTM Docs`;
+    const outputsJson = $localize`:@@diagram.edge.outputs-json:Outputs JSON`;
+    const sources = $localize`:@@diagram.subgraph.sources:Sources`;
+    const tagBuild = $localize`:@@diagram.subgraph.tag-build:Tag Build`;
 
-  getLocalizedSvgPath(): string {
-    const assetSegment = getLocaleConfig(this.locale).assetSegment;
-    return `/assets/i18n/${assetSegment}/tag_build_system_${assetSegment}.drawio.svg`;
+    return `flowchart TD
+  subgraph src["${sources}"]
+    GA4["${ga4}"]
+    Docs["${docs}"]
+  end
+  subgraph proc["${tagBuild}"]
+    Spec["${spec}"]
+    TB["TagBuild"]
+  end
+  GTM["GTM"]
+  GA4  --> Spec
+  GA4  --> TB
+  Docs --> TB
+  Spec --> TB
+  TB   -->|"${outputsJson}"| GTM`;
   }
 }

--- a/libs/ui/src/lib/components/mermaid-diagram/mermaid-diagram.component.scss
+++ b/libs/ui/src/lib/components/mermaid-diagram/mermaid-diagram.component.scss
@@ -1,0 +1,68 @@
+:host {
+  display: block;
+}
+
+.mermaid-skeleton {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: 8px;
+  background: linear-gradient(90deg, #f0f0f0 25%, #e4e4e4 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: mermaid-shimmer 1.5s ease-in-out infinite;
+}
+
+.mermaid-error {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  border: 1px dashed #ccc;
+  border-radius: 8px;
+  color: #555;
+  font-size: 1.4rem;
+
+  &__retry {
+    padding: 0.4rem 1rem;
+    border: 1px solid #bbb;
+    border-radius: 4px;
+    background: #fff;
+    color: #333;
+    cursor: pointer;
+    font-size: 1.4rem;
+    transition: background 0.15s ease;
+
+    &:hover {
+      background: #f5f5f5;
+    }
+
+    &:focus-visible {
+      outline: 2px solid #2563eb;
+      outline-offset: 2px;
+    }
+  }
+}
+
+.mermaid-container {
+  width: 100%;
+  overflow-x: auto;
+
+  /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
+  ::ng-deep svg {
+    max-width: 100%;
+    height: auto;
+    border-radius: 8px;
+    display: block;
+  }
+}
+
+@keyframes mermaid-shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}

--- a/libs/ui/src/lib/components/mermaid-diagram/mermaid-diagram.component.ts
+++ b/libs/ui/src/lib/components/mermaid-diagram/mermaid-diagram.component.ts
@@ -1,0 +1,112 @@
+import {
+  Component,
+  DestroyRef,
+  ElementRef,
+  afterNextRender,
+  effect,
+  inject,
+  input,
+  signal
+} from '@angular/core';
+
+let mermaidInitialized = false;
+
+type RenderStatus = 'loading' | 'done' | 'error';
+
+@Component({
+  selector: 'lib-mermaid-diagram',
+  standalone: true,
+  template: `
+    @if (status() === 'loading') {
+      <div class="mermaid-skeleton" aria-hidden="true"></div>
+    }
+    @if (status() === 'error') {
+      <div class="mermaid-error">
+        <span role="alert" i18n="@@mermaid.error.message"
+          >Failed to load diagram.</span
+        >
+        <button type="button" class="mermaid-error__retry" (click)="retry()">
+          <span i18n="@@mermaid.error.retry">Retry</span>
+        </button>
+      </div>
+    }
+    <div class="mermaid-container"></div>
+  `,
+  styleUrls: ['./mermaid-diagram.component.scss']
+})
+export class MermaidDiagramComponent {
+  readonly diagramDef = input.required<string>();
+  readonly ariaLabel = input('');
+
+  protected readonly status = signal<RenderStatus>('loading');
+
+  private readonly el = inject(ElementRef);
+  private readonly isBrowser = signal(false);
+  private destroyed = false;
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => {
+      this.destroyed = true;
+    });
+
+    afterNextRender(() => {
+      this.isBrowser.set(true);
+    });
+
+    effect(() => {
+      const def = this.diagramDef();
+      if (this.isBrowser() && def) {
+        void this.renderDiagram(def);
+      }
+    });
+  }
+
+  protected retry(): void {
+    const def = this.diagramDef();
+    if (def) {
+      void this.renderDiagram(def);
+    }
+  }
+
+  private async renderDiagram(def: string): Promise<void> {
+    this.status.set('loading');
+    try {
+      const { default: mermaid } = await import('mermaid');
+      if (!mermaidInitialized) {
+        mermaid.initialize({ startOnLoad: false, theme: 'neutral' });
+        mermaidInitialized = true;
+      }
+      const id = `mermaid-${Math.random().toString(36).slice(2)}`;
+      const { svg } = await mermaid.render(id, def);
+      if (this.destroyed) return;
+      const container = (this.el.nativeElement as HTMLElement).querySelector(
+        '.mermaid-container'
+      );
+      if (container) {
+        container.innerHTML = svg;
+        const svgEl = container.querySelector('svg');
+        if (svgEl) {
+          svgEl.setAttribute('role', 'img');
+          svgEl.setAttribute('focusable', 'false');
+          svgEl.setAttribute('tabindex', '-1');
+          const label = this.ariaLabel();
+          if (label) {
+            svgEl.setAttribute('aria-label', label);
+          }
+        }
+        this.status.set('done');
+      }
+    } catch {
+      if (this.destroyed) return;
+      this.status.set('error');
+      // After @if re-renders the error state, restore keyboard focus to the Retry button
+      // (the previously focused button is destroyed by Angular's @if teardown)
+      setTimeout(() => {
+        const btn = (
+          this.el.nativeElement as HTMLElement
+        ).querySelector<HTMLButtonElement>('.mermaid-error__retry');
+        btn?.focus();
+      });
+    }
+  }
+}

--- a/libs/ui/src/lib/components/objectives/objectives.component.html
+++ b/libs/ui/src/lib/components/objectives/objectives.component.html
@@ -3,34 +3,40 @@
     <h1 class="objectives__heading" i18n="@@objectives.achievement.title">
       Achievement
     </h1>
-    <figure class="objectives__figure">
-      <img
-        class="objectives__diagram"
-        [src]="getLocalizedSvgPath()"
-        i18n-alt="@@objectives.diagram.alt"
-        alt="Diagram showing the Tag Check System architecture and workflow"
-      />
-    </figure>
-    <div class="objectives__content">
-      <p i18n="@@objectives.achievement.intro">
-        The GTM Tag Build provides a user-friendly interface for digital
-        marketers and SEO experts to generate JSON files for Google Tag Manager.
-        This tool streamlines tag management by:
-      </p>
-      <ul class="objectives__list">
-        <li i18n="@@objectives.achievement.list.item1">
-          Reducing technical complexities
-        </li>
-        <li i18n="@@objectives.achievement.list.item2">
-          Enabling effortless creation of accurate JSON files
-        </li>
-        <li i18n="@@objectives.achievement.list.item3">
-          Enhancing productivity
-        </li>
-        <li i18n="@@objectives.achievement.list.item4">
-          Ensuring error-free tag management
-        </li>
-      </ul>
+    <div class="objectives__achievement-layout">
+      <div class="objectives__content">
+        <p i18n="@@objectives.achievement.intro">
+          The GTM Tag Build provides a user-friendly interface for digital
+          marketers and SEO experts to generate JSON files for Google Tag
+          Manager. This tool streamlines tag management by:
+        </p>
+        <ul class="objectives__list">
+          <li i18n="@@objectives.achievement.list.item1">
+            Reducing technical complexities
+          </li>
+          <li i18n="@@objectives.achievement.list.item2">
+            Enabling effortless creation of accurate JSON files
+          </li>
+          <li i18n="@@objectives.achievement.list.item3">
+            Enhancing productivity
+          </li>
+          <li i18n="@@objectives.achievement.list.item4">
+            Ensuring error-free tag management
+          </li>
+        </ul>
+      </div>
+      <figure class="objectives__diagram">
+        <lib-mermaid-diagram
+          [diagramDef]="tagCheckDiagram"
+          [ariaLabel]="tagCheckDiagramLabel"
+        />
+        <figcaption
+          class="objectives__diagram-caption"
+          i18n="@@diagram.caption.tag-check"
+        >
+          Fig. 2 — Tag Check workflow
+        </figcaption>
+      </figure>
     </div>
   </section>
 

--- a/libs/ui/src/lib/components/objectives/objectives.component.scss
+++ b/libs/ui/src/lib/components/objectives/objectives.component.scss
@@ -1,37 +1,41 @@
 @use 'libs/shared-styles/src/variables.scss' as *;
 
 .objectives {
-  max-width: $content-max;
+  max-width: 1200px;
   margin: 0 auto;
-  padding-inline: $space-gutter;
+  padding-inline: clamp(2rem, 5vw, 4rem);
   padding-block: 1rem;
 
-  // Section styling
   &__section {
     margin-bottom: 2rem;
   }
 
-  // Figure and image styling
-  &__figure {
-    margin: 1rem 0;
+  &__achievement-layout {
+    display: grid;
+    grid-template-columns: 1fr min(38rem, 46%);
+    gap: 2.5rem;
+    align-items: start;
   }
 
   &__diagram {
-    float: right;
-    max-width: min(60%, 32rem);
-    margin: 0 0 1rem 1.25rem;
-    border-radius: 5px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    height: auto;
+    position: sticky;
+    top: 2rem;
   }
 
-  // Content styling
+  &__diagram-caption {
+    margin-top: 0.5rem;
+    font-size: $font-size-caption;
+    color: var(--color-text-muted, #666);
+    text-align: center;
+  }
+
   &__content {
     margin-bottom: 1.5rem;
 
     p {
       margin-bottom: 1rem;
-      line-height: 1.6;
+      font-size: $font-size-body-read;
+      line-height: 1.7;
       text-align: justify;
       text-justify: inter-word;
     }
@@ -42,12 +46,13 @@
 
     li {
       margin-bottom: 0.5rem;
-      line-height: 1.4;
+      font-size: 1.6rem;
+      line-height: 1.5;
     }
   }
 
   a {
-    color: #2563eb; // Bright blue for good visibility
+    color: #2563eb;
     text-decoration: none;
     text-decoration-thickness: 0.1em;
     text-underline-offset: 0.2em;
@@ -55,54 +60,42 @@
     padding: 0.1em 0.2em;
     border-radius: 2px;
 
-    // Link state
     &:link {
       color: #2563eb;
     }
-
-    // Visited state
     &:visited {
-      color: #7c3aed; // Purple shade
+      color: #7c3aed;
     }
 
-    // Hover state
     &:hover {
-      color: #1e40af; // Darker blue
+      color: #1e40af;
       background-color: rgba(37, 99, 235, 0.1);
       text-decoration-thickness: 0.2em;
     }
 
-    // Focus state (for accessibility)
     &:focus {
       outline: 2px solid #2563eb;
       outline-offset: 2px;
       background-color: rgba(37, 99, 235, 0.1);
     }
 
-    // Active state
     &:active {
-      color: #1e3a8a; // Even darker blue
+      color: #1e3a8a;
       background-color: rgba(37, 99, 235, 0.2);
     }
   }
 
-  // Responsive breakpoints
   @media (max-width: ($bp-laptop - 1)) {
+    &__achievement-layout {
+      grid-template-columns: 1fr;
+    }
+
     &__diagram {
-      float: none;
-      max-width: 100%;
-      margin: 1rem 0;
-      display: block;
+      position: static;
     }
 
-    &__content {
-      p {
-        text-align: left;
-      }
-    }
-
-    &__code-container {
-      gap: 1rem;
+    &__content p {
+      text-align: left;
     }
   }
 
@@ -110,7 +103,7 @@
     padding-inline: 0.5rem;
 
     &__heading {
-      font-size: 1.25rem;
+      font-size: 2rem;
     }
 
     &__list {

--- a/libs/ui/src/lib/components/objectives/objectives.component.spec.ts
+++ b/libs/ui/src/lib/components/objectives/objectives.component.spec.ts
@@ -1,4 +1,3 @@
-import { LOCALE_ID } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { ObjectivesComponent } from './objectives.component';
@@ -6,8 +5,7 @@ import { ObjectivesComponent } from './objectives.component';
 describe('ObjectivesComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ObjectivesComponent],
-      providers: [{ provide: LOCALE_ID, useValue: 'zh-hant' }]
+      imports: [ObjectivesComponent]
     }).compileComponents();
   });
 
@@ -16,10 +14,19 @@ describe('ObjectivesComponent', () => {
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('returns a localized SVG path that includes the active locale', () => {
+  it('builds a mermaid diagram definition containing all key nodes', () => {
     const fixture = TestBed.createComponent(ObjectivesComponent);
-    expect(fixture.componentInstance.getLocalizedSvgPath()).toBe(
-      '/assets/i18n/zh-hant/tag_check_system_zh-hant.drawio.svg'
-    );
+    const diagram = fixture.componentInstance.tagCheckDiagram;
+    expect(diagram).toContain('flowchart TD');
+    expect(diagram).toContain('TagBuild');
+    expect(diagram).toContain('TagCheck');
+    expect(diagram).toContain('GTM');
+  });
+
+  it('exposes a non-empty aria label for the diagram', () => {
+    const fixture = TestBed.createComponent(ObjectivesComponent);
+    expect(
+      fixture.componentInstance.tagCheckDiagramLabel.length
+    ).toBeGreaterThan(0);
   });
 });

--- a/libs/ui/src/lib/components/objectives/objectives.component.ts
+++ b/libs/ui/src/lib/components/objectives/objectives.component.ts
@@ -1,16 +1,49 @@
-import { Component, Inject, LOCALE_ID } from '@angular/core';
-import { getLocaleConfig } from '../../locale/locale-routing';
+import { Component } from '@angular/core';
+import { MermaidDiagramComponent } from '../mermaid-diagram/mermaid-diagram.component';
 
 @Component({
   selector: 'lib-objectives',
   standalone: true,
+  imports: [MermaidDiagramComponent],
   templateUrl: './objectives.component.html',
   styleUrls: ['./objectives.component.scss']
 })
 export class ObjectivesComponent {
-  constructor(@Inject(LOCALE_ID) private readonly locale: string) {}
-  getLocalizedSvgPath(): string {
-    const assetSegment = getLocaleConfig(this.locale).assetSegment;
-    return `/assets/i18n/${assetSegment}/tag_check_system_${assetSegment}.drawio.svg`;
+  readonly tagCheckDiagram = this.buildTagCheckDiagram();
+  readonly tagCheckDiagramLabel = $localize`:@@diagram.aria.tag-check:Tag Check workflow: TagBuild outputs GTM JSON that runs on the website; TagCheck monitors GTM and the website against the Specification to surface issues`;
+
+  private buildTagCheckDiagram(): string {
+    const spec = $localize`:@@diagram.node.specification:Specification`;
+    const ga4 = $localize`:@@diagram.node.ga4events:GA4 Events`;
+    const docs = $localize`:@@diagram.node.gtmdocs:GTM Docs`;
+    const website = $localize`:@@diagram.node.website:website`;
+    const outputsJson = $localize`:@@diagram.edge.outputs-json:Outputs JSON`;
+    const definesEvents = $localize`:@@diagram.edge.defines-events:defines events`;
+    const runsOn = $localize`:@@diagram.edge.runs-on:runs on`;
+    const monitors = $localize`:@@diagram.edge.monitors:monitors`;
+    const sources = $localize`:@@diagram.subgraph.sources:Sources`;
+    const tagBuild = $localize`:@@diagram.subgraph.tag-build:Tag Build`;
+
+    return `flowchart TD
+  subgraph src["${sources}"]
+    GA4["${ga4}"]
+    Docs["${docs}"]
+  end
+  subgraph build["${tagBuild}"]
+    Spec["${spec}"]
+    TB["TagBuild"]
+  end
+  GTM["GTM"]
+  Web["${website}"]
+  TC["TagCheck"]
+  GA4  --> Spec
+  GA4  --> TB
+  Docs --> TB
+  Spec --> TB
+  Spec -->|"${definesEvents}"| TC
+  TB   -->|"${outputsJson}"| GTM
+  GTM  -->|"${runsOn}"| Web
+  GTM  -->|"${monitors}"| TC
+  Web  -->|"${monitors}"| TC`;
   }
 }


### PR DESCRIPTION
## Summary

### New Features
- **MermaidDiagramComponent** (`libs/ui`): reusable Mermaid renderer with loading/error/done states, DestroyRef guard, singleton `mermaid.initialize()`, full a11y support (role=img, aria-label, tabindex=-1, role=alert on error)
- **About page**: "How It Works" section restructured to full-width below the grid, with side-by-side GA4 Event vs Tag Build code blocks

### Improvements
- **Objectives page**: Tag Check flowchart updated with `monitors` edge labels
- **Typography**: Added SCSS tokens `$font-size-body-read` (17px) and `$font-size-caption` (14px) with 62.5% root font-size baseline
- **Layout**: Page padding widened with `clamp(2rem, 5vw, 4rem)`, max-width expanded to 1200px

### Bug Fixes

### i18n
- Added keys for mermaid error/retry messages, diagram captions, code block labels across all 4 locales (en-US, zh-Hant, zh-Hans, ja)