### PR TITLE
fix(ng-gtm-sample): load GTM after confirmed consent

### DIFF
--- a/apps/ng-gtm-sample/src/app/app.component.spec.ts
+++ b/apps/ng-gtm-sample/src/app/app.component.spec.ts
@@ -1,0 +1,65 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppComponent } from './app.component';
+import { SeoService } from './seo/seo.service';
+import { ConsentService } from './shared/services/consent/consent.service';
+import { LoadingService } from './shared/services/loading/loading.service';
+import { UrlTrackerService } from './shared/services/url-tracker/url-tracker.service';
+
+describe('AppComponent', () => {
+  const seoService = {
+    start: vi.fn()
+  };
+  const urlTrackerService = {
+    initializeUrlTracking: vi.fn()
+  };
+  const loadingService = {
+    getLoadingState: vi.fn(() => signal(false))
+  };
+  const consentServiceFactory = vi.fn(() => ({}));
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    seoService.start.mockReset();
+    urlTrackerService.initializeUrlTracking.mockReset();
+    loadingService.getLoadingState.mockClear();
+    consentServiceFactory.mockClear();
+    delete (globalThis as { dataLayer?: Array<Record<string, unknown>> })
+      .dataLayer;
+  });
+
+  it('instantiates the consent service globally when the app starts', () => {
+    TestBed.configureTestingModule({
+      imports: [AppComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: SeoService,
+          useValue: seoService
+        },
+        {
+          provide: UrlTrackerService,
+          useValue: urlTrackerService
+        },
+        {
+          provide: LoadingService,
+          useValue: loadingService
+        },
+        {
+          provide: ConsentService,
+          useFactory: consentServiceFactory
+        }
+      ]
+    });
+
+    const fixture: ComponentFixture<AppComponent> =
+      TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+
+    expect(consentServiceFactory).toHaveBeenCalledTimes(1);
+    expect(seoService.start).toHaveBeenCalledTimes(1);
+    expect(urlTrackerService.initializeUrlTracking).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ng-gtm-sample/src/app/app.component.ts
+++ b/apps/ng-gtm-sample/src/app/app.component.ts
@@ -4,6 +4,7 @@ import { RouterOutlet } from '@angular/router';
 import { SeoService } from './seo/seo.service';
 import { UrlTrackerService } from './shared/services/url-tracker/url-tracker.service';
 import { LoadingService } from './shared/services/loading/loading.service';
+import { ConsentService } from './shared/services/consent/consent.service';
 
 @Component({
   selector: 'app-root',
@@ -13,12 +14,12 @@ import { LoadingService } from './shared/services/loading/loading.service';
 export class AppComponent {
   private readonly platformId = inject(PLATFORM_ID);
   private readonly browser = isPlatformBrowser(this.platformId);
+  private readonly seoService = inject(SeoService);
+  private readonly urlTrackerService = inject(UrlTrackerService);
+  private readonly loadingService = inject(LoadingService);
+  private readonly consentService = inject(ConsentService);
 
-  constructor(
-    private readonly seoService: SeoService,
-    private readonly urlTrackerService: UrlTrackerService,
-    private readonly loadingService: LoadingService
-  ) {
+  constructor() {
     this.seoService.start();
 
     const loading = this.loadingService.getLoadingState();

--- a/apps/ng-gtm-sample/src/app/shared/components/cookie-consent/cookie-consent.component.html
+++ b/apps/ng-gtm-sample/src/app/shared/components/cookie-consent/cookie-consent.component.html
@@ -2,6 +2,7 @@
   styleClass="w-[min(42rem,calc(100vw-1.5rem))]"
   [(visible)]="showModal"
   [modal]="true"
+  [closable]="false"
   [closeOnEscape]="false"
   [dismissableMask]="false"
   (onHide)="hide()"
@@ -17,10 +18,7 @@
             sample storefront.
           </div>
         </div>
-        <p-toggleswitch
-          [(ngModel)]="analyticsModel"
-          (onChange)="acceptAnalytics($event)"
-        />
+        <p-toggleswitch [(ngModel)]="analyticsModel" />
       </div>
       <div class="text-sm leading-6 text-slate-600">
         Analytics cookies track site usage and trends to improve your browsing
@@ -36,10 +34,7 @@
             Power attribution and performance measurement events.
           </div>
         </div>
-        <p-toggleswitch
-          [(ngModel)]="measurementModel"
-          (onChange)="acceptMeasurement($event)"
-        />
+        <p-toggleswitch [(ngModel)]="measurementModel" />
       </div>
       <div class="text-sm leading-6 text-slate-600">
         Measurement cookies for performance measurement.
@@ -53,10 +48,7 @@
             Control personalization and audience-building signals.
           </div>
         </div>
-        <p-toggleswitch
-          [(ngModel)]="audienceModel"
-          (onChange)="acceptAudience($event)"
-        />
+        <p-toggleswitch [(ngModel)]="audienceModel" />
       </div>
       <div class="text-sm leading-6 text-slate-600">
         Audience cookies to share marketing content relevant to you.
@@ -70,7 +62,7 @@
       label="Save Preferences"
       severity="secondary"
       [outlined]="true"
-      (click)="hide(); consent()"
+      (click)="savePreferences()"
     ></button>
     <button
       pButton

--- a/apps/ng-gtm-sample/src/app/shared/components/cookie-consent/cookie-consent.component.spec.ts
+++ b/apps/ng-gtm-sample/src/app/shared/components/cookie-consent/cookie-consent.component.spec.ts
@@ -1,0 +1,224 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ConsentCategories,
+  ConsentService
+} from '../../services/consent/consent.service';
+import { CookieConsentComponent } from './cookie-consent.component';
+
+function createConsentServiceMock(initialCategories: ConsentCategories) {
+  const categories = signal<ConsentCategories>(initialCategories);
+
+  return {
+    consentCategories$: () => categories(),
+    updateConsentCategories: vi.fn((nextCategories: ConsentCategories) => {
+      categories.set(nextCategories);
+    }),
+    hasConsent: vi.fn()
+  };
+}
+
+describe('CookieConsentComponent', () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    localStorage.clear();
+  });
+
+  it('keeps local measurement model off when analytics is toggled before save', async () => {
+    const consentService = createConsentServiceMock({
+      analytics: false,
+      measurement: false,
+      audience: false
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [CookieConsentComponent],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: ConsentService,
+          useValue: consentService
+        }
+      ]
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(CookieConsentComponent);
+    fixture.detectChanges();
+
+    fixture.componentInstance.analyticsModel = true;
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.analyticsModel).toBe(true);
+    expect(fixture.componentInstance.measurementModel).toBe(false);
+    expect(fixture.componentInstance.audienceModel).toBe(false);
+    expect(consentService.updateConsentCategories).not.toHaveBeenCalled();
+  });
+
+  it('allows local measurement to turn off while analytics remains on without saving', async () => {
+    const consentService = createConsentServiceMock({
+      analytics: true,
+      measurement: true,
+      audience: false
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [CookieConsentComponent],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: ConsentService,
+          useValue: consentService
+        }
+      ]
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(CookieConsentComponent);
+    fixture.detectChanges();
+
+    fixture.componentInstance.measurementModel = false;
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.analyticsModel).toBe(true);
+    expect(fixture.componentInstance.measurementModel).toBe(false);
+    expect(fixture.componentInstance.audienceModel).toBe(false);
+    expect(consentService.updateConsentCategories).not.toHaveBeenCalled();
+  });
+
+  it('restores confirmed stored categories into the UI models', async () => {
+    localStorage.setItem('consent', 'true');
+    localStorage.setItem(
+      'consentCategories',
+      JSON.stringify({
+        analytics: true,
+        measurement: false,
+        audience: true
+      })
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [CookieConsentComponent],
+      providers: [provideNoopAnimations()]
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(CookieConsentComponent);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.analyticsModel).toBe(true);
+    expect(fixture.componentInstance.measurementModel).toBe(false);
+    expect(fixture.componentInstance.audienceModel).toBe(true);
+  });
+
+  it('allow all grants every first-class consent category', async () => {
+    const consentService = createConsentServiceMock({
+      analytics: false,
+      measurement: false,
+      audience: false
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [CookieConsentComponent],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: ConsentService,
+          useValue: consentService
+        }
+      ]
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(CookieConsentComponent);
+    fixture.detectChanges();
+
+    fixture.componentInstance.acceptAll();
+    fixture.detectChanges();
+
+    expect(consentService.updateConsentCategories).toHaveBeenLastCalledWith({
+      analytics: true,
+      measurement: true,
+      audience: true
+    });
+    expect(consentService.hasConsent).toHaveBeenCalledTimes(1);
+    expect(fixture.componentInstance.analyticsModel).toBe(true);
+    expect(fixture.componentInstance.measurementModel).toBe(true);
+    expect(fixture.componentInstance.audienceModel).toBe(true);
+    expect(fixture.componentInstance.showModal()).toBe(false);
+  });
+
+  it('disables all dialog close controls that bypass explicit preference actions', async () => {
+    const consentService = createConsentServiceMock({
+      analytics: false,
+      measurement: false,
+      audience: false
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [CookieConsentComponent],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: ConsentService,
+          useValue: consentService
+        }
+      ]
+    }).compileComponents();
+
+    const fixture: ComponentFixture<CookieConsentComponent> =
+      TestBed.createComponent(CookieConsentComponent);
+    fixture.detectChanges();
+
+    const dialog = fixture.debugElement.query(By.css('p-dialog'))
+      .componentInstance as {
+      closable: boolean;
+      closeOnEscape: boolean;
+      dismissableMask: boolean;
+    };
+
+    expect(dialog.closable).toBe(false);
+    expect(dialog.closeOnEscape).toBe(false);
+    expect(dialog.dismissableMask).toBe(false);
+  });
+
+  it('commits local models only when Save Preferences is confirmed', async () => {
+    const consentService = createConsentServiceMock({
+      analytics: false,
+      measurement: false,
+      audience: false
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [CookieConsentComponent],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: ConsentService,
+          useValue: consentService
+        }
+      ]
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(CookieConsentComponent);
+    fixture.detectChanges();
+
+    fixture.componentInstance.show();
+    fixture.componentInstance.analyticsModel = true;
+    fixture.componentInstance.measurementModel = false;
+    fixture.componentInstance.audienceModel = true;
+    fixture.detectChanges();
+
+    expect(consentService.updateConsentCategories).not.toHaveBeenCalled();
+
+    fixture.componentInstance.savePreferences();
+    fixture.detectChanges();
+
+    expect(consentService.updateConsentCategories).toHaveBeenLastCalledWith({
+      analytics: true,
+      measurement: false,
+      audience: true
+    });
+    expect(consentService.hasConsent).toHaveBeenCalledTimes(1);
+    expect(fixture.componentInstance.showModal()).toBe(false);
+  });
+});

--- a/apps/ng-gtm-sample/src/app/shared/components/cookie-consent/cookie-consent.component.ts
+++ b/apps/ng-gtm-sample/src/app/shared/components/cookie-consent/cookie-consent.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   effect,
+  inject,
   input,
   signal
 } from '@angular/core';
@@ -10,10 +11,7 @@ import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { DialogModule } from 'primeng/dialog';
 import { ButtonModule } from 'primeng/button';
-import {
-  ToggleSwitchChangeEvent,
-  ToggleSwitchModule
-} from 'primeng/toggleswitch';
+import { ToggleSwitchModule } from 'primeng/toggleswitch';
 
 @Component({
   selector: 'app-cookie-consent',
@@ -39,20 +37,14 @@ export class CookieConsentComponent {
   showModalInput = input<boolean>(false);
   showCookieConsentInput = input<boolean>(false);
 
-  constructor(public consentService: ConsentService) {
-    const storedConsentPreferences =
-      this.consentService.loadStoredConsentPreferences();
+  readonly consentService = inject(ConsentService);
 
-    if (storedConsentPreferences) {
-      this.consentService.setConsentPreferences(storedConsentPreferences);
-    } else {
-      this.consentService.initConsentPreferences();
-    }
-
+  constructor() {
     effect(() => {
-      this.analyticsModel = this.consentService.analyticsConsentGiven$();
-      this.measurementModel = this.consentService.measurementConsentGiven$();
-      this.audienceModel = this.consentService.audienceConsentGiven$();
+      const categories = this.consentService.consentCategories$();
+      this.analyticsModel = categories.analytics;
+      this.measurementModel = categories.measurement;
+      this.audienceModel = categories.audience;
     });
 
     effect(() => {
@@ -77,40 +69,27 @@ export class CookieConsentComponent {
     this.showCookieConsent.set(false);
   }
 
-  acceptAnalytics(event: ToggleSwitchChangeEvent) {
-    this.updateConsentModels({ analytics: event.checked });
-  }
-
-  acceptMeasurement(event: ToggleSwitchChangeEvent) {
-    this.updateConsentModels({ measurement: event.checked });
-  }
-
-  acceptAudience(event: ToggleSwitchChangeEvent) {
-    this.updateConsentModels({ audience: event.checked });
-  }
-
-  acceptCookies(event: ToggleSwitchChangeEvent) {
-    this.updateConsentModels({
-      analytics: event.checked,
-      measurement: event.checked,
-      audience: event.checked
+  savePreferences() {
+    this.consentService.updateConsentCategories({
+      analytics: this.analyticsModel,
+      measurement: this.measurementModel,
+      audience: this.audienceModel
     });
-    this.hide();
     this.consent();
+    this.hide();
   }
 
   acceptAll() {
-    this.consentService.updateConsentPreferences({
-      ad_storage: true,
-      analytics_storage: true,
-      ad_user_data: true,
-      ad_personalization: true
-    });
     this.analyticsModel = true;
     this.measurementModel = true;
     this.audienceModel = true;
-    this.hide();
+    this.consentService.updateConsentCategories({
+      analytics: true,
+      measurement: true,
+      audience: true
+    });
     this.consent();
+    this.hide();
   }
 
   switchModal() {
@@ -119,23 +98,5 @@ export class CookieConsentComponent {
 
   consent() {
     this.consentService.hasConsent();
-  }
-
-  private updateConsentModels(input: {
-    analytics?: boolean;
-    measurement?: boolean;
-    audience?: boolean;
-  }) {
-    const analytics = input.analytics ?? this.analyticsModel;
-    const measurement = input.measurement ?? this.measurementModel;
-    const audience = input.audience ?? this.audienceModel;
-    const grantsSharedStorage = analytics || measurement || audience;
-
-    this.consentService.updateConsentPreferences({
-      analytics_storage: analytics,
-      ad_storage: grantsSharedStorage,
-      ad_user_data: grantsSharedStorage,
-      ad_personalization: audience
-    });
   }
 }

--- a/apps/ng-gtm-sample/src/app/shared/services/consent/consent.service.spec.ts
+++ b/apps/ng-gtm-sample/src/app/shared/services/consent/consent.service.spec.ts
@@ -1,0 +1,428 @@
+import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ConsentCategories,
+  ConsentPreferences,
+  ConsentService,
+  GTM_SCRIPT_ID,
+  GTM_SCRIPT_SRC
+} from './consent.service';
+
+const allCategories: ConsentCategories = {
+  analytics: true,
+  measurement: true,
+  audience: true
+};
+
+const deniedCategories: ConsentCategories = {
+  analytics: false,
+  measurement: false,
+  audience: false
+};
+
+const deniedConsent: ConsentPreferences = {
+  analytics_storage: false,
+  ad_storage: false,
+  ad_user_data: false,
+  ad_personalization: false
+};
+
+function configureConsentService(platformId = 'browser') {
+  TestBed.configureTestingModule({
+    providers: [
+      ConsentService,
+      {
+        provide: PLATFORM_ID,
+        useValue: platformId
+      }
+    ]
+  });
+
+  return TestBed.inject(ConsentService);
+}
+
+function dataLayer() {
+  return (globalThis as { dataLayer: Array<Record<string, unknown>> })
+    .dataLayer;
+}
+
+function expectLatestConsentUpdate(expected: Record<string, string>) {
+  const consentEvents = dataLayer().filter(
+    (event) => event['event'] === 'update_consent'
+  );
+
+  expect(consentEvents.at(-1)).toEqual({
+    event: 'update_consent',
+    ...expected
+  });
+}
+
+function expectGtmLoadAfterConsentUpdate(
+  expectedConsent: Record<string, string>
+) {
+  expect(dataLayer()).toEqual([
+    {
+      event: 'update_consent',
+      ...expectedConsent
+    },
+    {
+      'gtm.start': expect.any(Number),
+      event: 'gtm.js'
+    }
+  ]);
+}
+
+function resetBrowserState() {
+  localStorage.clear();
+  document.getElementById(GTM_SCRIPT_ID)?.remove();
+  delete (globalThis as { dataLayer?: Array<Record<string, unknown>> })
+    .dataLayer;
+}
+
+describe('ConsentService', () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    resetBrowserState();
+  });
+
+  it('initializes default denied categories without loading GTM or writing categories', () => {
+    const service = configureConsentService();
+
+    expect(service.consentCategories$()).toEqual(deniedCategories);
+    expect(service.consentPreferences$()).toEqual(deniedConsent);
+    expect(document.getElementById(GTM_SCRIPT_ID)).toBeNull();
+    expect(localStorage.getItem('consentCategories')).toBeNull();
+  });
+
+  it('persists consent categories and derives conservative consent preferences', () => {
+    const service = configureConsentService();
+
+    service.updateConsentCategories({
+      analytics: true,
+      measurement: false,
+      audience: false
+    });
+
+    expect(service.consentCategories$()).toEqual({
+      analytics: true,
+      measurement: false,
+      audience: false
+    });
+    expect(service.consentPreferences$()).toEqual({
+      analytics_storage: true,
+      ad_storage: false,
+      ad_user_data: false,
+      ad_personalization: false
+    });
+    expect(localStorage.getItem('consentCategories')).toBe(
+      JSON.stringify({
+        analytics: true,
+        measurement: false,
+        audience: false
+      })
+    );
+  });
+
+  it('maps measurement-only categories to ad storage and user data without personalization', () => {
+    const service = configureConsentService();
+
+    service.updateConsentCategories({
+      analytics: false,
+      measurement: true,
+      audience: false
+    });
+
+    expect(service.consentPreferences$()).toEqual({
+      analytics_storage: false,
+      ad_storage: true,
+      ad_user_data: true,
+      ad_personalization: false
+    });
+    expectLatestConsentUpdate({
+      ad_storage: 'granted',
+      analytics_storage: 'denied',
+      ad_user_data: 'granted',
+      ad_personalization: 'denied'
+    });
+  });
+
+  it('restores stored categories at startup before deriving preferences and loading GTM', () => {
+    localStorage.setItem('consent', 'true');
+    localStorage.setItem(
+      'consentCategories',
+      JSON.stringify({
+        analytics: false,
+        measurement: true,
+        audience: false
+      })
+    );
+    const appendChildSpy = vi.spyOn(document.head, 'appendChild');
+
+    appendChildSpy.mockImplementation((node: Node) => {
+      expectGtmLoadAfterConsentUpdate({
+        ad_storage: 'granted',
+        analytics_storage: 'denied',
+        ad_user_data: 'granted',
+        ad_personalization: 'denied'
+      });
+      return HTMLElement.prototype.appendChild.call(document.head, node);
+    });
+
+    const service = configureConsentService();
+
+    expect(service.consentCategories$()).toEqual({
+      analytics: false,
+      measurement: true,
+      audience: false
+    });
+    expect(service.consentPreferences$()).toEqual({
+      analytics_storage: false,
+      ad_storage: true,
+      ad_user_data: true,
+      ad_personalization: false
+    });
+    expect(document.getElementById(GTM_SCRIPT_ID)).toBeTruthy();
+
+    appendChildSpy.mockRestore();
+  });
+
+  it('uses conservative legacy fallback when categories are absent', () => {
+    localStorage.setItem('consent', 'true');
+    localStorage.setItem(
+      'consentPreferences',
+      JSON.stringify({
+        analytics_storage: true,
+        ad_storage: true,
+        ad_user_data: true,
+        ad_personalization: false
+      })
+    );
+
+    const service = configureConsentService();
+
+    expect(service.consentCategories$()).toEqual({
+      analytics: true,
+      measurement: true,
+      audience: false
+    });
+    expect(service.consentPreferences$()).toEqual({
+      analytics_storage: true,
+      ad_storage: true,
+      ad_user_data: true,
+      ad_personalization: false
+    });
+    expect(document.getElementById(GTM_SCRIPT_ID)).toBeTruthy();
+  });
+
+  it('handles inconsistent legacy fallback with null/undefined safety', () => {
+    localStorage.setItem('consent', 'true');
+    localStorage.setItem(
+      'consentPreferences',
+      JSON.stringify({
+        analytics_storage: 1,
+        ad_storage: true,
+        ad_personalization: true
+      })
+    );
+
+    const service = configureConsentService();
+
+    expect(service.consentCategories$()).toEqual({
+      analytics: true,
+      measurement: false,
+      audience: false
+    });
+    expect(service.consentPreferences$()).toEqual({
+      analytics_storage: true,
+      ad_storage: false,
+      ad_user_data: false,
+      ad_personalization: false
+    });
+  });
+
+  it('ignores unconfirmed stored categories and keeps default denied without loading GTM', () => {
+    localStorage.setItem(
+      'consentCategories',
+      JSON.stringify({
+        analytics: true,
+        measurement: true,
+        audience: true
+      })
+    );
+
+    const service = configureConsentService();
+
+    expect(service.consentCategories$()).toEqual(deniedCategories);
+    expect(service.consentPreferences$()).toEqual(deniedConsent);
+    expect(document.getElementById(GTM_SCRIPT_ID)).toBeNull();
+    expect(
+      (globalThis as { dataLayer?: Array<Record<string, unknown>> }).dataLayer
+    ).toBeUndefined();
+  });
+
+  it('ignores unconfirmed legacy preferences and keeps default denied without loading GTM', () => {
+    localStorage.setItem(
+      'consentPreferences',
+      JSON.stringify({
+        analytics_storage: true,
+        ad_storage: true,
+        ad_user_data: true,
+        ad_personalization: true
+      })
+    );
+
+    const service = configureConsentService();
+
+    expect(service.consentCategories$()).toEqual(deniedCategories);
+    expect(service.consentPreferences$()).toEqual(deniedConsent);
+    expect(document.getElementById(GTM_SCRIPT_ID)).toBeNull();
+  });
+
+  it('falls back to default denied when confirmed stored categories are malformed', () => {
+    localStorage.setItem('consent', 'true');
+    localStorage.setItem('consentCategories', '{not-json');
+
+    expect(() => configureConsentService()).not.toThrow();
+
+    const service = TestBed.inject(ConsentService);
+
+    expect(service.consentCategories$()).toEqual(deniedCategories);
+    expect(service.consentPreferences$()).toEqual(deniedConsent);
+    expect(document.getElementById(GTM_SCRIPT_ID)).toBeNull();
+  });
+
+  it('loads GTM after analytics-only consent and preserves update_consent', () => {
+    const service = configureConsentService();
+
+    service.updateConsentCategories({
+      analytics: true,
+      measurement: false,
+      audience: false
+    });
+
+    const script = document.getElementById(GTM_SCRIPT_ID) as HTMLScriptElement;
+    expect(script).toBeTruthy();
+    expect(script.src).toBe(GTM_SCRIPT_SRC);
+    expect(script.async).toBe(true);
+    expectGtmLoadAfterConsentUpdate({
+      ad_storage: 'denied',
+      analytics_storage: 'granted',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied'
+    });
+  });
+
+  it('loads GTM after measurement-only consent', () => {
+    const service = configureConsentService();
+
+    service.updateConsentCategories({
+      analytics: false,
+      measurement: true,
+      audience: false
+    });
+
+    expect(document.getElementById(GTM_SCRIPT_ID)).toBeTruthy();
+    expectGtmLoadAfterConsentUpdate({
+      ad_storage: 'granted',
+      analytics_storage: 'denied',
+      ad_user_data: 'granted',
+      ad_personalization: 'denied'
+    });
+  });
+
+  it('keeps explicitly denied categories from loading GTM', () => {
+    const service = configureConsentService();
+
+    service.updateConsentCategories(deniedCategories);
+
+    expect(document.getElementById(GTM_SCRIPT_ID)).toBeNull();
+    expectLatestConsentUpdate({
+      ad_storage: 'denied',
+      analytics_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied'
+    });
+  });
+
+  it('does not create duplicate GTM scripts on repeated grants', () => {
+    const service = configureConsentService();
+
+    service.updateConsentCategories(allCategories);
+    service.updateConsentCategories({
+      analytics: true,
+      measurement: false,
+      audience: false
+    });
+
+    expect(document.querySelectorAll(`#${GTM_SCRIPT_ID}`)).toHaveLength(1);
+  });
+
+  it('falls back to default consent when stored categories cannot be read', () => {
+    const getItemSpy = vi
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation(() => {
+        throw new DOMException('blocked', 'SecurityError');
+      });
+
+    expect(() => configureConsentService()).not.toThrow();
+    expect(document.getElementById(GTM_SCRIPT_ID)).toBeNull();
+
+    getItemSpy.mockRestore();
+  });
+
+  it('keeps in-memory category updates when storage writes are blocked', () => {
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new DOMException('blocked', 'SecurityError');
+      });
+
+    const service = configureConsentService();
+    service.updateConsentCategories({
+      analytics: true,
+      measurement: false,
+      audience: false
+    });
+
+    expect(service.consentCategories$()).toEqual({
+      analytics: true,
+      measurement: false,
+      audience: false
+    });
+    expect(document.getElementById(GTM_SCRIPT_ID)).toBeTruthy();
+
+    setItemSpy.mockRestore();
+  });
+
+  it('stays server-safe without reading storage or loading GTM', () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem');
+
+    const service = configureConsentService('server');
+    service.updateConsentCategories(allCategories);
+
+    expect(service.consentCategories$()).toEqual(allCategories);
+    expect(getItemSpy).not.toHaveBeenCalled();
+    expect(document.getElementById(GTM_SCRIPT_ID)).toBeNull();
+
+    getItemSpy.mockRestore();
+  });
+
+  it('correctly sets and retrieves consent status', () => {
+    const service = configureConsentService();
+
+    expect(service.getConsentStatus()).toBe(false);
+
+    service.hasConsent();
+
+    expect(service.getConsentStatus()).toBe(true);
+    expect(localStorage.getItem('consent')).toBe('true');
+  });
+
+  it('safely handles invalid/unparseable consent status', () => {
+    const service = configureConsentService();
+    localStorage.setItem('consent', 'invalid-json');
+
+    expect(service.getConsentStatus()).toBe(false);
+  });
+});

--- a/apps/ng-gtm-sample/src/app/shared/services/consent/consent.service.ts
+++ b/apps/ng-gtm-sample/src/app/shared/services/consent/consent.service.ts
@@ -1,4 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import {
   computed,
   Injectable,
@@ -7,12 +7,24 @@ import {
   signal
 } from '@angular/core';
 
+export interface ConsentCategories {
+  analytics: boolean;
+  measurement: boolean;
+  audience: boolean;
+}
+
 export interface ConsentPreferences {
   analytics_storage: boolean;
   ad_storage: boolean;
   ad_user_data: boolean;
   ad_personalization: boolean;
 }
+
+const DEFAULT_CONSENT_CATEGORIES: ConsentCategories = {
+  analytics: false,
+  measurement: false,
+  audience: false
+};
 
 const DEFAULT_CONSENT_PREFERENCES: ConsentPreferences = {
   analytics_storage: false,
@@ -21,49 +33,120 @@ const DEFAULT_CONSENT_PREFERENCES: ConsentPreferences = {
   ad_personalization: false
 };
 
+const CONSENT_CATEGORIES_STORAGE_KEY = 'consentCategories';
+const CONSENT_PREFERENCES_STORAGE_KEY = 'consentPreferences';
+
+export const GTM_CONTAINER_ID = 'GTM-NBMX2DWS';
+export const GTM_SCRIPT_ID = `gtm-script-${GTM_CONTAINER_ID}`;
+export const GTM_SCRIPT_SRC = `https://www.googletagmanager.com/gtm.js?id=${GTM_CONTAINER_ID}`;
+
 @Injectable({
   providedIn: 'root'
 })
 export class ConsentService {
   private readonly browser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly document = inject(DOCUMENT);
+  private readonly consentCategories = signal<ConsentCategories>(
+    DEFAULT_CONSENT_CATEGORIES
+  );
   private readonly consentPreferences = signal<ConsentPreferences>(
     DEFAULT_CONSENT_PREFERENCES
   );
 
+  readonly consentCategories$ = computed(() => this.consentCategories());
   readonly consentPreferences$ = computed(() => this.consentPreferences());
-  readonly analyticsConsentGiven$ = computed(() => {
-    const consentOptions = this.consentPreferences();
-    return (
-      consentOptions.analytics_storage &&
-      consentOptions.ad_storage &&
-      consentOptions.ad_user_data
-    );
-  });
-  readonly measurementConsentGiven$ = computed(() => {
-    const consentOptions = this.consentPreferences();
-    return consentOptions.ad_storage && consentOptions.ad_user_data;
-  });
-  readonly audienceConsentGiven$ = computed(() => {
-    const consentOptions = this.consentPreferences();
-    return (
-      consentOptions.ad_storage &&
-      consentOptions.ad_user_data &&
-      consentOptions.ad_personalization
-    );
-  });
+  readonly analyticsConsentGiven$ = computed(
+    () => this.consentCategories().analytics
+  );
+  readonly measurementConsentGiven$ = computed(
+    () => this.consentCategories().measurement
+  );
+  readonly audienceConsentGiven$ = computed(
+    () => this.consentCategories().audience
+  );
+
+  constructor() {
+    if (!this.getConsentStatus()) {
+      this.initConsentPreferences();
+      return;
+    }
+
+    const storedConsentCategories = this.loadStoredConsentCategories();
+
+    if (storedConsentCategories) {
+      this.applyConsentCategories(storedConsentCategories, {
+        persist: false,
+        syncDataLayer: true,
+        loadGtmWhenGranted: true
+      });
+      return;
+    }
+
+    const legacyConsentPreferences = this.loadStoredConsentPreferences();
+
+    if (legacyConsentPreferences) {
+      this.applyConsentCategories(
+        this.deriveCategoriesFromLegacyPreferences(legacyConsentPreferences),
+        {
+          persist: false,
+          syncDataLayer: true,
+          loadGtmWhenGranted: true
+        }
+      );
+      return;
+    }
+
+    this.initConsentPreferences();
+  }
 
   initConsentPreferences() {
-    this.setConsentPreferences(DEFAULT_CONSENT_PREFERENCES);
+    this.setConsentCategories(DEFAULT_CONSENT_CATEGORIES, { persist: false });
   }
 
   setConsentPreferences(consentPreferences: ConsentPreferences) {
-    this.consentPreferences.set(consentPreferences);
+    this.updateConsentPreferences(consentPreferences);
+  }
 
-    if (this.browser) {
-      localStorage.setItem(
-        'consentPreferences',
-        JSON.stringify(consentPreferences)
+  setConsentCategories(
+    consentCategories: ConsentCategories,
+    options: { persist: boolean } = { persist: true }
+  ) {
+    const normalizedCategories =
+      this.normalizeConsentCategories(consentCategories);
+    this.consentCategories.set(normalizedCategories);
+    this.consentPreferences.set(
+      this.deriveConsentPreferences(normalizedCategories)
+    );
+
+    if (this.browser && options.persist) {
+      this.setLocalStorageItem(
+        CONSENT_CATEGORIES_STORAGE_KEY,
+        JSON.stringify(normalizedCategories)
       );
+      this.setLocalStorageItem(
+        CONSENT_PREFERENCES_STORAGE_KEY,
+        JSON.stringify(this.consentPreferences())
+      );
+    }
+  }
+
+  loadStoredConsentCategories(): ConsentCategories | null {
+    if (!this.browser) {
+      return null;
+    }
+
+    const storedCategories = this.getLocalStorageItem(
+      CONSENT_CATEGORIES_STORAGE_KEY
+    );
+
+    if (!storedCategories) {
+      return null;
+    }
+
+    try {
+      return this.normalizeConsentCategories(JSON.parse(storedCategories));
+    } catch {
+      return null;
     }
   }
 
@@ -72,26 +155,140 @@ export class ConsentService {
       return null;
     }
 
-    const storedPreferences = localStorage.getItem('consentPreferences');
+    const storedPreferences = this.getLocalStorageItem(
+      CONSENT_PREFERENCES_STORAGE_KEY
+    );
 
     if (!storedPreferences) {
       return null;
     }
 
     try {
-      return {
-        ...DEFAULT_CONSENT_PREFERENCES,
-        ...JSON.parse(storedPreferences)
-      } as ConsentPreferences;
+      return this.normalizeConsentPreferences(JSON.parse(storedPreferences));
     } catch {
       return null;
     }
   }
 
-  updateConsentPreferences(consentPreferences: ConsentPreferences) {
-    this.setConsentPreferences(consentPreferences);
+  updateConsentCategories(consentCategories: ConsentCategories) {
+    this.applyConsentCategories(consentCategories, {
+      persist: true,
+      syncDataLayer: true,
+      loadGtmWhenGranted: true
+    });
+  }
 
-    const consentPreferencesDataLayer = {
+  updateConsentPreferences(consentPreferences: ConsentPreferences) {
+    this.applyConsentCategories(
+      this.deriveCategoriesFromLegacyPreferences(consentPreferences),
+      {
+        persist: true,
+        syncDataLayer: true,
+        loadGtmWhenGranted: true
+      }
+    );
+  }
+
+  hasConsent() {
+    if (this.browser) {
+      this.setLocalStorageItem('consent', 'true');
+    }
+  }
+
+  getConsentStatus() {
+    if (!this.browser) {
+      return false;
+    }
+
+    try {
+      return JSON.parse(this.getLocalStorageItem('consent') || 'false');
+    } catch {
+      return false;
+    }
+  }
+
+  private applyConsentCategories(
+    consentCategories: ConsentCategories,
+    options: {
+      persist: boolean;
+      syncDataLayer: boolean;
+      loadGtmWhenGranted: boolean;
+    }
+  ) {
+    this.setConsentCategories(consentCategories, { persist: options.persist });
+
+    if (options.syncDataLayer) {
+      this.syncConsentToDataLayer(this.consentPreferences());
+    }
+
+    if (
+      options.loadGtmWhenGranted &&
+      this.canLoadGtm(this.consentCategories())
+    ) {
+      this.loadGtmScript();
+    }
+  }
+
+  private deriveConsentPreferences(
+    consentCategories: ConsentCategories
+  ): ConsentPreferences {
+    return {
+      analytics_storage: consentCategories.analytics,
+      ad_storage: consentCategories.measurement || consentCategories.audience,
+      ad_user_data: consentCategories.measurement || consentCategories.audience,
+      ad_personalization: consentCategories.audience
+    };
+  }
+
+  private deriveCategoriesFromLegacyPreferences(
+    consentPreferences: ConsentPreferences
+  ): ConsentCategories {
+    const legacy = this.normalizeConsentPreferences(consentPreferences);
+    const audience = !!(
+      legacy.ad_personalization &&
+      legacy.ad_storage &&
+      legacy.ad_user_data
+    );
+
+    return {
+      analytics: !!legacy.analytics_storage,
+      audience,
+      measurement: !!(legacy.ad_storage && legacy.ad_user_data && !audience)
+    };
+  }
+
+  private normalizeConsentCategories(input: Partial<ConsentCategories> | null) {
+    return {
+      analytics: !!input?.analytics,
+      measurement: !!input?.measurement,
+      audience: !!input?.audience
+    };
+  }
+
+  private normalizeConsentPreferences(
+    input: Partial<ConsentPreferences> | null
+  ): ConsentPreferences {
+    return {
+      analytics_storage: !!input?.analytics_storage,
+      ad_storage: !!input?.ad_storage,
+      ad_user_data: !!input?.ad_user_data,
+      ad_personalization: !!input?.ad_personalization
+    };
+  }
+
+  private syncConsentToDataLayer(consentPreferences: ConsentPreferences) {
+    if (!this.browser) {
+      return;
+    }
+
+    this.getDataLayer().push({
+      event: 'update_consent',
+      ...this.toDataLayerConsent(consentPreferences)
+    });
+  }
+
+  private toDataLayerConsent(consentPreferences: ConsentPreferences) {
+    return {
       ad_storage: consentPreferences.ad_storage ? 'granted' : 'denied',
       analytics_storage: consentPreferences.analytics_storage
         ? 'granted'
@@ -101,27 +298,48 @@ export class ConsentService {
         ? 'granted'
         : 'denied'
     };
+  }
 
-    if (this.browser) {
-      this.getDataLayer().push({
-        event: 'update_consent',
-        ...consentPreferencesDataLayer
-      });
+  private canLoadGtm(consentCategories: ConsentCategories) {
+    return (
+      consentCategories.analytics ||
+      consentCategories.measurement ||
+      consentCategories.audience
+    );
+  }
+
+  private loadGtmScript() {
+    if (!this.browser || this.document.getElementById(GTM_SCRIPT_ID)) {
+      return;
+    }
+
+    this.getDataLayer().push({
+      'gtm.start': Date.now(),
+      event: 'gtm.js'
+    });
+
+    const script = this.document.createElement('script');
+    script.id = GTM_SCRIPT_ID;
+    script.async = true;
+    script.src = GTM_SCRIPT_SRC;
+    this.document.head.appendChild(script);
+  }
+
+  private getLocalStorageItem(key: string) {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
     }
   }
 
-  hasConsent() {
-    if (this.browser) {
-      localStorage.setItem('consent', 'true');
+  private setLocalStorageItem(key: string, value: string) {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Ignore storage failures so privacy-restricted browsers can still run
+      // with in-memory consent defaults.
     }
-  }
-
-  getConsentStatus() {
-    if (!this.browser) {
-      return false;
-    }
-
-    return JSON.parse(localStorage.getItem('consent') || 'false');
   }
 
   private getDataLayer(): Array<Record<string, unknown>> {


### PR DESCRIPTION
﻿## Summary
- Gate `ng-gtm-sample` GTM loading behind explicit confirmed consent instead of loading from unconfirmed toggle interactions.
- Add persisted granular consent categories and conservative GTM Consent Mode mapping before injecting `GTM-NBMX2DWS`.
- Add focused service/component/app tests for consent restoration, GTM script ordering, malformed storage safety, and dialog close controls.

## Test plan
- [x] `pnpm nx run ng-gtm-sample:test --skipNxCache -- --run`
- [x] `pnpm nx run ng-gtm-sample:build:development --skipNxCache`
- [x] Local browser smoke: before consent no GTM request; after Allow All, `gtm.js?id=GTM-NBMX2DWS` loads with HTTP 200; reload restores confirmed consent and loads GTM after `update_consent`.

## Review / verification
- Plan Review passed via `gemini-3.5-flash-high`.
- Test Review passed via `gemini-3.5-flash-high` after privacy-remediation findings were addressed.
- Implementation Review fallback passed via `gemini-3.5-flash-high` after Copilot fallback was locally unavailable due provider auth.

## Risk
- Privacy-sensitive consent and third-party script loading path; mitigated by explicit confirmation before persistence/script injection, conservative consent mapping, idempotent GTM injection, and unit/browser verification.
