### PR TITLE
fix: sync release versions from latest authority

### DIFF
--- a/apps/desktop-tauri/src-tauri/Cargo.toml
+++ b/apps/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop-tauri"
-version = "2.1.0"
+version = "2.1.1"
 description = "Tag Check Desktop"
 authors = ["Guan Xin Wang"]
 license = ""

--- a/apps/desktop-tauri/src-tauri/tauri.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Tag Check Desktop",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "identifier": "com.wodenwang.tagcheck.desktop",
   "build": {
     "frontendDist": "../../../dist/apps/ng-frontend/browser",

--- a/tools/scripts/tauri/release/release-contract.ts
+++ b/tools/scripts/tauri/release/release-contract.ts
@@ -215,14 +215,13 @@ export function readCanonicalVersion() {
 }
 
 export function readVersionAuthorities(): VersionAuthorities {
-  const packageJson = readJsonFile<{ version: string }>(packageJsonPath);
-  const tauriConfig = readJsonFile<{ version: string }>(tauriConfigPath);
+  const authorities = readRawVersionAuthorities();
 
   return {
-    cargoManifest: readCargoManifestVersion(),
-    packageJson: parseStableVersion(packageJson.version),
-    tauriConfig: parseStableVersion(tauriConfig.version),
-    versionFile: readCanonicalVersion()
+    cargoManifest: parseStableVersion(authorities.cargoManifest),
+    packageJson: parseStableVersion(authorities.packageJson),
+    tauriConfig: parseStableVersion(authorities.tauriConfig),
+    versionFile: parseStableVersion(authorities.versionFile)
   };
 }
 
@@ -283,12 +282,79 @@ export function assertVersionAuthoritiesInSync(expectedVersion?: string) {
   return resolvedVersion;
 }
 
-export function syncVersionAuthorities(version = readCanonicalVersion()) {
-  const normalizedVersion = parseStableVersion(version);
+function readRawVersionAuthorities(): VersionAuthorities {
+  const packageJson = readJsonFile<{ version: string }>(packageJsonPath);
+  const tauriConfig = readJsonFile<{ version: string }>(tauriConfigPath);
+  const cargoManifest = readFileSync(cargoManifestPath, 'utf8');
+  const { section } = getCargoPackageSection(cargoManifest);
+  const cargoVersionMatch = section.match(
+    /^version\s*=\s*"(?<version>[^"]+)"/m
+  );
+
+  if (!cargoVersionMatch?.groups?.version) {
+    throw new Error(
+      `Unable to read the package version from ${cargoManifestPath}.`
+    );
+  }
+
+  return {
+    cargoManifest: cargoVersionMatch.groups.version,
+    packageJson: packageJson.version,
+    tauriConfig: tauriConfig.version,
+    versionFile: readFileSync(versionFilePath, 'utf8')
+  };
+}
+
+function tryParseStableVersion(version: string) {
+  try {
+    return parseStableVersion(version);
+  } catch {
+    return undefined;
+  }
+}
+
+function compareStableVersions(left: string, right: string) {
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+
+  for (let index = 0; index < leftParts.length; index += 1) {
+    const difference = leftParts[index] - rightParts[index];
+
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}
+
+function resolveLatestStableVersionAuthority() {
+  const validVersions = Object.values(readRawVersionAuthorities())
+    .map(tryParseStableVersion)
+    .filter((version): version is string => Boolean(version));
+
+  if (validVersions.length === 0) {
+    throw new Error(
+      'Unable to synchronize versions because no stable version authority was found.'
+    );
+  }
+
+  return validVersions.reduce((latestVersion, candidateVersion) =>
+    compareStableVersions(candidateVersion, latestVersion) > 0
+      ? candidateVersion
+      : latestVersion
+  );
+}
+
+export function syncVersionAuthorities(version?: string) {
+  const normalizedVersion = version
+    ? parseStableVersion(version)
+    : resolveLatestStableVersionAuthority();
   const packageJson = readJsonFile<Record<string, unknown>>(packageJsonPath);
   const tauriConfig = readJsonFile<Record<string, unknown>>(tauriConfigPath);
   const cargoManifest = readFileSync(cargoManifestPath, 'utf8');
 
+  writeFileSync(versionFilePath, `${normalizedVersion}\n`, 'utf8');
   writeJsonFile(packageJsonPath, {
     ...packageJson,
     version: normalizedVersion

--- a/tools/scripts/tauri/release/release.spec.ts
+++ b/tools/scripts/tauri/release/release.spec.ts
@@ -859,26 +859,29 @@ describe('release helper', () => {
     );
   });
 
-  it('synchronizes package.json, tauri.conf.json, and Cargo.toml from VERSION', async () => {
+  it('synchronizes VERSION, package.json, tauri.conf.json, and Cargo.toml to the latest authority version', async () => {
     const { releaseContractModule, workspaceRoot } =
       await loadReleaseContractWorkspaceModule({
-        cargoManifest: '2.0.0',
+        cargoManifest: '2.1.0',
         packageJson: '2.0.0',
-        tauriConfig: '2.0.0',
-        versionFile: '2.1.0'
+        tauriConfig: '2.2.0',
+        versionFile: '2.0.1'
       });
 
-    expect(releaseContractModule.syncVersionAuthorities()).toBe('2.1.0');
+    expect(releaseContractModule.syncVersionAuthorities()).toBe('2.2.0');
     expect(releaseContractModule.readVersionAuthorities()).toEqual({
-      cargoManifest: '2.1.0',
-      packageJson: '2.1.0',
-      tauriConfig: '2.1.0',
-      versionFile: '2.1.0'
+      cargoManifest: '2.2.0',
+      packageJson: '2.2.0',
+      tauriConfig: '2.2.0',
+      versionFile: '2.2.0'
     });
+    expect(readFileSync(join(workspaceRoot, 'VERSION'), 'utf8')).toBe(
+      '2.2.0\n'
+    );
     expect(
       JSON.parse(readFileSync(join(workspaceRoot, 'package.json'), 'utf8'))
     ).toMatchObject({
-      version: '2.1.0'
+      version: '2.2.0'
     });
     expect(
       JSON.parse(
@@ -894,14 +897,78 @@ describe('release helper', () => {
         )
       )
     ).toMatchObject({
-      version: '2.1.0'
+      version: '2.2.0'
     });
     expect(
       readFileSync(
         join(workspaceRoot, 'apps', 'desktop-tauri', 'src-tauri', 'Cargo.toml'),
         'utf8'
       )
-    ).toContain('version = "2.1.0"');
+    ).toContain('version = "2.2.0"');
+  });
+
+  it('uses numeric semver ordering when selecting the latest version authority', async () => {
+    const { releaseContractModule } = await loadReleaseContractWorkspaceModule({
+      cargoManifest: '2.9.9',
+      packageJson: '2.10.0',
+      tauriConfig: '2.0.0',
+      versionFile: '2.1.0'
+    });
+
+    expect(releaseContractModule.syncVersionAuthorities()).toBe('2.10.0');
+    expect(releaseContractModule.readVersionAuthorities()).toEqual({
+      cargoManifest: '2.10.0',
+      packageJson: '2.10.0',
+      tauriConfig: '2.10.0',
+      versionFile: '2.10.0'
+    });
+  });
+
+  it('ignores malformed version authorities when a stable version can be recovered', async () => {
+    const { releaseContractModule } = await loadReleaseContractWorkspaceModule({
+      cargoManifest: '2.1.0-beta.1',
+      packageJson: '2.3.0',
+      tauriConfig: 'invalid',
+      versionFile: '2.2.0'
+    });
+
+    expect(releaseContractModule.syncVersionAuthorities()).toBe('2.3.0');
+    expect(releaseContractModule.readVersionAuthorities()).toEqual({
+      cargoManifest: '2.3.0',
+      packageJson: '2.3.0',
+      tauriConfig: '2.3.0',
+      versionFile: '2.3.0'
+    });
+  });
+
+  it('fails to synchronize when no stable version authority can be recovered', async () => {
+    const { releaseContractModule } = await loadReleaseContractWorkspaceModule({
+      cargoManifest: 'invalid',
+      packageJson: 'invalid',
+      tauriConfig: 'invalid',
+      versionFile: 'invalid'
+    });
+
+    expect(() => releaseContractModule.syncVersionAuthorities()).toThrow(
+      'Unable to synchronize versions because no stable version authority was found.'
+    );
+  });
+
+  it('allows explicit sync-version callers to choose the target version', async () => {
+    const { releaseContractModule } = await loadReleaseContractWorkspaceModule({
+      cargoManifest: '2.3.0',
+      packageJson: '2.2.0',
+      tauriConfig: '2.1.0',
+      versionFile: '2.0.0'
+    });
+
+    expect(releaseContractModule.syncVersionAuthorities('2.1.1')).toBe('2.1.1');
+    expect(releaseContractModule.readVersionAuthorities()).toEqual({
+      cargoManifest: '2.1.1',
+      packageJson: '2.1.1',
+      tauriConfig: '2.1.1',
+      versionFile: '2.1.1'
+    });
   });
 
   it('keeps sync-version idempotent when Cargo.toml already matches VERSION', async () => {

--- a/tools/scripts/tauri/release/release.ts
+++ b/tools/scripts/tauri/release/release.ts
@@ -133,7 +133,7 @@ async function checkVersionAuthoritiesCommand(args: string[]) {
 async function syncVersionAuthoritiesCommand() {
   const version = syncVersionAuthorities();
   console.log(
-    `Synchronized package.json, tauri.conf.json, and Cargo.toml to VERSION ${version}.`
+    `Synchronized VERSION, package.json, tauri.conf.json, and Cargo.toml to version ${version}.`
   );
 }
 


### PR DESCRIPTION
﻿## Summary

- update the desktop release version sync helper so `pnpm run version:sync` resolves the newest stable semver across `VERSION`, `package.json`, `tauri.conf.json`, and `Cargo.toml`
- write the resolved version back to all four authorities while keeping `version:check` strict for release safety
- add regression coverage for numeric semver ordering, malformed authority recovery, explicit sync targets, missing release notes, and the no-valid-version failure path
- add `docs/releases/2.1.1.md` so the release workflow has a matching body file for the current version
- add a focused `test:release-tools` script and run it in the Build workflow so missing release notes fail during PR CI instead of after merge/release
- synchronize the current Tauri desktop manifests to `2.1.1`

## Validation

- `pnpm review:plan:risky -- --context-file <plan>`
- `pnpm review:test -- --context-file <test-review>`
- `pnpm review:implementation -- --context-file <implementation-review>`
- `pnpm run test:release-tools` => 34 passed
- `pnpm exec vitest run tools/scripts/tauri/release/release.spec.ts` => 34 passed
- `pnpm run version:sync`
- `pnpm run version:check` => `{ "version": "2.1.1" }`
- `git diff --check`
- pre-commit hook: `lint-staged` passed; `nx affected --target=test --base=HEAD --parallel=6` reported no tasks

## Notes

`startup-timing.log` remains an unrelated local modification and is not included in this PR.
