### PR TITLE
fix: make release tooling tests host independent

### DIFF
--- a/tools/scripts/tauri/release/release.spec.ts
+++ b/tools/scripts/tauri/release/release.spec.ts
@@ -35,6 +35,8 @@ import {
 
 const temporaryDirectories: string[] = [];
 const fixtureVersion = '2.0.0';
+const originalArch = process.arch;
+const originalPlatform = process.platform;
 const fixturePlatformDefinitions = [
   {
     bundleTarget: 'nsis',
@@ -62,6 +64,14 @@ const fixturePlatformDefinitions = [
 }>;
 
 afterEach(() => {
+  Object.defineProperty(process, 'arch', {
+    configurable: true,
+    value: originalArch
+  });
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: originalPlatform
+  });
   for (const directory of temporaryDirectories.splice(0)) {
     rmSync(directory, { force: true, recursive: true });
   }
@@ -225,13 +235,25 @@ function writeFixtureArtifact(
   };
 }
 
+// Bundle tests default to a Windows host so they remain hermetic on Linux CI.
+// Pass hostPlatform/hostArch explicitly when adding non-Windows host assertions.
 async function loadBundleReleaseTestModule(
   options: {
     buildError?: Error;
+    hostArch?: NodeJS.Architecture;
+    hostPlatform?: NodeJS.Platform;
     rawBundleContents?: string;
     rustTargetTriple?: string;
   } = {}
 ) {
+  Object.defineProperty(process, 'arch', {
+    configurable: true,
+    value: options.hostArch ?? 'x64'
+  });
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: options.hostPlatform ?? 'win32'
+  });
   const rawBundleDirectory = createFixtureDirectory();
   const releaseAssetsRoot = createFixtureDirectory();
   const runSyncCommandOrThrow = vi.fn((input: unknown) => {


### PR DESCRIPTION
﻿## Summary

- make the Tauri release bundle tests hermetic by mocking `process.platform` and `process.arch` in the bundle-test helper
- restore the original process host properties in `afterEach` before other cleanup so state cannot leak across tests
- keep `test:release-tools` running the full release spec, preserving all 34 tests while allowing Ubuntu Build runners to pass

## Failure fixed

GitHub Actions Build failed in the `Release tooling tests` step because the full release spec executed Windows bundle tests on an Ubuntu runner:

```text
Error: The windows release must be built on win32, but this host is linux.
```

## Validation

- `pnpm review:plan -- --context-file <plan>`
- `pnpm review:test -- --context-file <test-review>`
- `pnpm review:implementation -- --context-file <implementation-review>`
- `pnpm run test:release-tools` => 34 passed
- `pnpm run version:check` => `{ "version": "2.1.1" }`
- `git diff --check`
- commit hook: `lint-staged` passed; `nx affected --target=test --base=HEAD --parallel=6` reported no tasks

## Notes

This is a follow-up after PR #466 exposed that the full release spec was not host-independent on Linux. `startup-timing.log` remains an unrelated local modification and is not included.
